### PR TITLE
Start Android backend layer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,9 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_SKIP_RPATH ON)
 
 add_executable(${PROJECT_NAME})
+if(ANDROID)
+  add_subdirectory(android)
+endif()
 
 if(MSVC)
   add_definitions(-D_USE_MATH_DEFINES)

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -1,0 +1,20 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.opengothic.launcher">
+  <uses-feature android:name="android.hardware.touchscreen.multitouch" />
+  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+
+  <application android:label="OpenGothic" android:hasCode="true">
+    <activity android:name="android.app.NativeActivity"
+              android:label="OpenGothic"
+              android:configChanges="orientation|keyboardHidden|screenSize"
+              android:screenOrientation="landscape"
+              android:exported="true">
+      <meta-data android:name="android.app.lib_name" android:value="OpenGothic" />
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+    </activity>
+  </application>
+</manifest>

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_library(OpenGothic SHARED
+    ../backend/android/android_main.cpp
+    ../backend/android/AndroidInputBackend.cpp
+    ../backend/android/AndroidAudioBackend.cpp
+    ../backend/android/AndroidFileSystemBackend.cpp
+    ../backend/android/AndroidNativeGlue.cpp)
+
+target_include_directories(OpenGothic PRIVATE ../backend)
+
+target_link_libraries(OpenGothic log android)

--- a/backend/IAudioBackend.h
+++ b/backend/IAudioBackend.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <cstdint>
+
+class IAudioBackend {
+  public:
+    virtual ~IAudioBackend() = default;
+
+    virtual bool init() = 0;
+    virtual void shutdown() = 0;
+
+    virtual void playSample(const void* data,size_t size,int rate,int chan)=0;
+  };
+

--- a/backend/IFileSystemBackend.h
+++ b/backend/IFileSystemBackend.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <string>
+#include <vector>
+
+class IFileSystemBackend {
+  public:
+    virtual ~IFileSystemBackend() = default;
+
+    virtual std::vector<uint8_t> readAsset(const std::string& path) = 0;
+    virtual std::string userDirectory() const = 0;
+  };
+

--- a/backend/IInputBackend.h
+++ b/backend/IInputBackend.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <cstdint>
+#include <functional>
+
+class IInputBackend {
+  public:
+    virtual ~IInputBackend() = default;
+
+    using KeyCallback    = std::function<void(int32_t,bool)>;
+    using MotionCallback = std::function<void(float,float)>;
+
+    virtual void setKeyCallback(KeyCallback cb)    = 0;
+    virtual void setMotionCallback(MotionCallback cb) = 0;
+    virtual void pollEvents() = 0;
+  };
+

--- a/backend/INativeGlue.h
+++ b/backend/INativeGlue.h
@@ -1,0 +1,10 @@
+#pragma once
+
+class INativeGlue {
+  public:
+    virtual ~INativeGlue() = default;
+
+    virtual void onStart() = 0;
+    virtual void onStop()  = 0;
+  };
+

--- a/backend/android/AndroidAudioBackend.cpp
+++ b/backend/android/AndroidAudioBackend.cpp
@@ -1,0 +1,16 @@
+#include "AndroidAudioBackend.h"
+
+AndroidAudioBackend::AndroidAudioBackend() = default;
+AndroidAudioBackend::~AndroidAudioBackend() = default;
+
+bool AndroidAudioBackend::init() {
+  // TODO: initialize OpenSL/AAudio
+  return true;
+  }
+
+void AndroidAudioBackend::shutdown() {
+  }
+
+void AndroidAudioBackend::playSample(const void* ,size_t ,int ,int ) {
+  }
+

--- a/backend/android/AndroidAudioBackend.h
+++ b/backend/android/AndroidAudioBackend.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "../IAudioBackend.h"
+
+class AndroidAudioBackend : public IAudioBackend {
+  public:
+    AndroidAudioBackend();
+    ~AndroidAudioBackend() override;
+
+    bool init() override;
+    void shutdown() override;
+    void playSample(const void* data,size_t size,int rate,int chan) override;
+  };
+

--- a/backend/android/AndroidFileSystemBackend.cpp
+++ b/backend/android/AndroidFileSystemBackend.cpp
@@ -1,0 +1,27 @@
+#include "AndroidFileSystemBackend.h"
+#include <android/asset_manager.h>
+#include <android/asset_manager_jni.h>
+
+AndroidFileSystemBackend::AndroidFileSystemBackend(AAssetManager* m)
+  : mgr(m) {}
+
+AndroidFileSystemBackend::~AndroidFileSystemBackend() = default;
+
+std::vector<uint8_t> AndroidFileSystemBackend::readAsset(const std::string& path) {
+  std::vector<uint8_t> out;
+  if(!mgr)
+    return out;
+  AAsset* a = AAssetManager_open(mgr, path.c_str(), AASSET_MODE_BUFFER);
+  if(a){
+    size_t sz = AAsset_getLength(a);
+    out.resize(sz);
+    AAsset_read(a,out.data(),sz);
+    AAsset_close(a);
+    }
+  return out;
+  }
+
+std::string AndroidFileSystemBackend::userDirectory() const {
+  return "/sdcard/REGoth"; // placeholder
+  }
+

--- a/backend/android/AndroidFileSystemBackend.h
+++ b/backend/android/AndroidFileSystemBackend.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "../IFileSystemBackend.h"
+
+struct AAssetManager;
+
+class AndroidFileSystemBackend : public IFileSystemBackend {
+  public:
+    explicit AndroidFileSystemBackend(AAssetManager* mgr);
+    ~AndroidFileSystemBackend() override;
+
+    std::vector<uint8_t> readAsset(const std::string& path) override;
+    std::string userDirectory() const override;
+
+  private:
+    AAssetManager* mgr = nullptr;
+  };
+

--- a/backend/android/AndroidInputBackend.cpp
+++ b/backend/android/AndroidInputBackend.cpp
@@ -1,0 +1,17 @@
+#include "AndroidInputBackend.h"
+
+AndroidInputBackend::AndroidInputBackend() = default;
+AndroidInputBackend::~AndroidInputBackend() = default;
+
+void AndroidInputBackend::setKeyCallback(KeyCallback cb) {
+  keyCb = std::move(cb);
+  }
+
+void AndroidInputBackend::setMotionCallback(MotionCallback cb) {
+  motionCb = std::move(cb);
+  }
+
+void AndroidInputBackend::pollEvents() {
+  // TODO: hook into AInputQueue
+  }
+

--- a/backend/android/AndroidInputBackend.h
+++ b/backend/android/AndroidInputBackend.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "../IInputBackend.h"
+
+class AndroidInputBackend : public IInputBackend {
+  public:
+    AndroidInputBackend();
+    ~AndroidInputBackend() override;
+
+    void setKeyCallback(KeyCallback cb) override;
+    void setMotionCallback(MotionCallback cb) override;
+    void pollEvents() override;
+
+  private:
+    KeyCallback    keyCb;
+    MotionCallback motionCb;
+  };
+

--- a/backend/android/AndroidNativeGlue.cpp
+++ b/backend/android/AndroidNativeGlue.cpp
@@ -1,0 +1,14 @@
+#include "AndroidNativeGlue.h"
+
+AndroidNativeGlue::AndroidNativeGlue(ANativeActivity* act)
+  : activity(act) {}
+
+AndroidNativeGlue::~AndroidNativeGlue() = default;
+
+void AndroidNativeGlue::onStart() {
+  // placeholder for lifecycle
+  }
+
+void AndroidNativeGlue::onStop() {
+  }
+

--- a/backend/android/AndroidNativeGlue.h
+++ b/backend/android/AndroidNativeGlue.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "../INativeGlue.h"
+#include <android/native_activity.h>
+
+class AndroidNativeGlue : public INativeGlue {
+  public:
+    explicit AndroidNativeGlue(ANativeActivity* act);
+    ~AndroidNativeGlue() override;
+
+    void onStart() override;
+    void onStop() override;
+
+  private:
+    ANativeActivity* activity = nullptr;
+  };
+

--- a/backend/android/android_main.cpp
+++ b/backend/android/android_main.cpp
@@ -1,0 +1,20 @@
+#include <android/native_activity.h>
+#include <android/log.h>
+#include <android/native_window_jni.h>
+
+#include "AndroidInputBackend.h"
+#include "AndroidAudioBackend.h"
+#include "AndroidFileSystemBackend.h"
+#include "AndroidNativeGlue.h"
+
+extern "C" void GameMain(IInputBackend&,IAudioBackend&,IFileSystemBackend&,INativeGlue&);
+
+extern "C" void ANativeActivity_onCreate(ANativeActivity* activity,void*,size_t){
+  __android_log_print(ANDROID_LOG_INFO,"OpenGothic","activity created");
+  AndroidInputBackend  input;
+  AndroidAudioBackend  audio;
+  AndroidFileSystemBackend fs(activity->assetManager);
+  AndroidNativeGlue    glue(activity);
+  GameMain(input,audio,fs,glue);
+  }
+

--- a/docs/android_integration_guide.md
+++ b/docs/android_integration_guide.md
@@ -1,0 +1,26 @@
+# Android Integration Guide
+
+This guide describes how to embed the OpenGothic engine into a minimal
+`NativeActivity` based launcher. The approach follows the backend design with
+interfaces implemented in `backend/`.
+
+1. **Build system**
+   - The root `CMakeLists.txt` checks for `ANDROID` and includes the `android`
+     directory. The `android/CMakeLists.txt` builds `libOpenGothic.so` from the
+     backend sources and links against the NDK libraries.
+
+2. **Native entry point**
+   - `backend/android/android_main.cpp` exposes `ANativeActivity_onCreate` which
+     creates backend objects (`AndroidInputBackend`, `AndroidAudioBackend`,
+     `AndroidFileSystemBackend`, `AndroidNativeGlue`) and passes them to
+     `GameMain` – an exported function expected to start the engine.
+
+3. **Manifest**
+   - `android/AndroidManifest.xml` configures a landscape `NativeActivity` and
+     requests external storage permissions.
+
+4. **Extending the engine**
+   - Game code should call `GameMain` instead of `main` when built for Android
+     so that platform backends can be injected. Touch handling and asset loading
+     can then be implemented on top of the provided interfaces.
+

--- a/docs/regoth_legacy_analysis.md
+++ b/docs/regoth_legacy_analysis.md
@@ -1,0 +1,31 @@
+# REGoth Legacy Android Components
+
+This document lists Android specific pieces from `external/regoth_legacy` that are
+useful when building an Android launcher around OpenGothic.
+
+## Native glue
+- `src/engine/PlatformAndroid.cpp` and `PlatformAndroid.h` implement
+  `android_main`, input loop and JNI hooks for installer extraction.
+- `REGoth-Android/app` contains a Java launcher using `NativeActivity` and a
+  small bootstrap activity which loads the native library.
+
+## Input handling
+- Touch events are processed in `PlatformAndroid::onInputEvent` where two virtual
+  thumb sticks are emulated. Mappings are translated into engine actions.
+- Key bindings are configured via `bindKey` and processed each frame in
+  `PlatformAndroid::run`.
+
+## File system and installer helpers
+- Asset and save data location is defined via `CONTENT_BASE_PATH` pointing to
+  `/sdcard/REGoth`.
+- Installer extraction is handled through JNI functions
+  `Java_com_regothproject_regoth_InstallerExtract_*` which call
+  `zTools::extractInstaller`.
+
+## Audio backend
+- REGoth relied on OpenAL (see `src/audio`); OpenSL is configured in
+  `openal-soft` build scripts but not directly used from the engine code.
+
+These components can be ported by implementing small backend classes that expose
+input events, file access via `AAssetManager` and lifecycle hooks.
+


### PR DESCRIPTION
## Summary
- outline Android-specific loader and backend interfaces
- add skeleton backend implementations
- wire new build target when `ANDROID` is enabled
- document old REGoth code and integration steps

## Testing
- `cmake --version`

------
https://chatgpt.com/codex/tasks/task_e_685724badab4833181a92fc42ea1eea2