### PR TITLE
Implement basic Android input backend

### DIFF
--- a/backend/android/AndroidInputBackend.cpp
+++ b/backend/android/AndroidInputBackend.cpp
@@ -1,7 +1,46 @@
 #include "AndroidInputBackend.h"
+#include <android/looper.h>
+#include <android/log.h>
+#include <cstring>
 
-AndroidInputBackend::AndroidInputBackend() = default;
-AndroidInputBackend::~AndroidInputBackend() = default;
+namespace {
+  AndroidInputBackend* g_inst = nullptr;
+
+  int32_t mapKey(int32_t k){
+    switch(k){
+      case AKEYCODE_W: return 0x1100; // W key
+      case AKEYCODE_S: return 0x1f00; // S key
+      case AKEYCODE_A: return 0x1e00; // A key
+      case AKEYCODE_D: return 0x2000; // D key
+
+      case AKEYCODE_DPAD_UP:    return 0xc800; // Arrow up
+      case AKEYCODE_DPAD_DOWN:  return 0xd000; // Arrow down
+      case AKEYCODE_DPAD_LEFT:  return 0xcb00; // Arrow left
+      case AKEYCODE_DPAD_RIGHT: return 0xcd00; // Arrow right
+
+      case AKEYCODE_SPACE:      return 0x3900; // Space
+      case AKEYCODE_BUTTON_A:   return 0x3800; // Jump - Alt
+      case AKEYCODE_BUTTON_B:   return 0x1d00; // Action - Ctrl
+      case AKEYCODE_BUTTON_X:   return 0x3900; // Weapon/Action
+      case AKEYCODE_BUTTON_Y:   return 0x1e00; // Left? placeholder
+
+      case AKEYCODE_BACK:       return 0x0100; // Escape
+      case AKEYCODE_BUTTON_START:
+      case AKEYCODE_MENU:       return 0x0100; // Menu / Escape
+      default:
+        return 0;
+      }
+    }
+}
+
+AndroidInputBackend::AndroidInputBackend() {
+  g_inst = this;
+  }
+
+AndroidInputBackend::~AndroidInputBackend() {
+  if(g_inst==this)
+    g_inst=nullptr;
+  }
 
 void AndroidInputBackend::setKeyCallback(KeyCallback cb) {
   keyCb = std::move(cb);
@@ -12,6 +51,47 @@ void AndroidInputBackend::setMotionCallback(MotionCallback cb) {
   }
 
 void AndroidInputBackend::pollEvents() {
-  // TODO: hook into AInputQueue
+  // Pump looper so queued input events trigger callbacks
+  ALooper_pollAll(0,nullptr,nullptr,nullptr);
+  }
+
+int32_t AndroidInputBackend::onInputEvent(AInputEvent* event) {
+  if(event==nullptr)
+    return 0;
+
+  switch(AInputEvent_getType(event)) {
+    case AINPUT_EVENT_TYPE_KEY: {
+      int32_t code = mapKey(AKeyEvent_getKeyCode(event));
+      if(code!=0 && keyCb) {
+        bool pressed = (AKeyEvent_getAction(event)==AKEY_EVENT_ACTION_DOWN);
+        keyCb(code, pressed);
+        return 1;
+        }
+      break;
+      }
+    case AINPUT_EVENT_TYPE_MOTION: {
+      if(motionCb) {
+        const int32_t src = AInputEvent_getSource(event);
+        float x=0.f, y=0.f;
+        if(src & AINPUT_SOURCE_JOYSTICK) {
+          x = AMotionEvent_getAxisValue(reinterpret_cast<AMotionEvent*>(event), AMOTION_EVENT_AXIS_X, 0);
+          y = -AMotionEvent_getAxisValue(reinterpret_cast<AMotionEvent*>(event), AMOTION_EVENT_AXIS_Y, 0);
+        } else if(src & AINPUT_SOURCE_TOUCHSCREEN) {
+          x = AMotionEvent_getX(reinterpret_cast<AMotionEvent*>(event),0);
+          y = AMotionEvent_getY(reinterpret_cast<AMotionEvent*>(event),0);
+        }
+        motionCb(x,y);
+        return 1;
+        }
+      break;
+      }
+    }
+  return 0;
+  }
+
+extern "C" int32_t onInputEvent(AInputEvent* event) {
+  if(g_inst)
+    return g_inst->onInputEvent(event);
+  return 0;
   }
 

--- a/backend/android/AndroidInputBackend.h
+++ b/backend/android/AndroidInputBackend.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "../IInputBackend.h"
+#include <android/input.h>
 
 class AndroidInputBackend : public IInputBackend {
   public:
@@ -9,6 +10,9 @@ class AndroidInputBackend : public IInputBackend {
     void setKeyCallback(KeyCallback cb) override;
     void setMotionCallback(MotionCallback cb) override;
     void pollEvents() override;
+
+    /// Processes an Android input event. Called from native glue.
+    int32_t onInputEvent(AInputEvent* event);
 
   private:
     KeyCallback    keyCb;


### PR DESCRIPTION
## Summary
- implement Android input event handling
- map Android key codes and motion events to Gothic key codes

## Testing
- `cmake -S . -B build` *(fails: glslangValidator required)*

------
https://chatgpt.com/codex/tasks/task_e_685727d987cc8331aa0b2f0a5b6d0981