### PR TITLE
Integrate Android input backend

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -1,10 +1,12 @@
 add_library(OpenGothic SHARED
     ../backend/android/android_main.cpp
+    ${ANDROID_NDK}/sources/android/native_app_glue/android_native_app_glue.c
     ../backend/android/AndroidInputBackend.cpp
     ../backend/android/AndroidAudioBackend.cpp
     ../backend/android/AndroidFileSystemBackend.cpp
     ../backend/android/AndroidNativeGlue.cpp)
 
-target_include_directories(OpenGothic PRIVATE ../backend)
+target_include_directories(OpenGothic PRIVATE ../backend
+    ${ANDROID_NDK}/sources/android/native_app_glue)
 
 target_link_libraries(OpenGothic log android)

--- a/backend/IInputBackend.h
+++ b/backend/IInputBackend.h
@@ -1,6 +1,9 @@
 #pragma once
 #include <cstdint>
 #include <functional>
+#ifdef __ANDROID__
+#include <android/input.h>
+#endif
 
 class IInputBackend {
   public:
@@ -12,5 +15,10 @@ class IInputBackend {
     virtual void setKeyCallback(KeyCallback cb)    = 0;
     virtual void setMotionCallback(MotionCallback cb) = 0;
     virtual void pollEvents() = 0;
+
+#ifdef __ANDROID__
+    /// Processes a platform specific input event.
+    virtual int32_t onInputEvent(AInputEvent* event) = 0;
+#endif
   };
 

--- a/backend/android/AndroidInputBackend.cpp
+++ b/backend/android/AndroidInputBackend.cpp
@@ -1,6 +1,7 @@
 #include "AndroidInputBackend.h"
 #include <android/looper.h>
 #include <android/log.h>
+#define LOGI(...) __android_log_print(ANDROID_LOG_INFO,"InputBackend",__VA_ARGS__)
 #include <cstring>
 
 namespace {
@@ -8,10 +9,43 @@ namespace {
 
   int32_t mapKey(int32_t k){
     switch(k){
-      case AKEYCODE_W: return 0x1100; // W key
-      case AKEYCODE_S: return 0x1f00; // S key
-      case AKEYCODE_A: return 0x1e00; // A key
-      case AKEYCODE_D: return 0x2000; // D key
+      case AKEYCODE_A: return 0x1e00;
+      case AKEYCODE_B: return 0x3000;
+      case AKEYCODE_C: return 0x2e00;
+      case AKEYCODE_D: return 0x2000;
+      case AKEYCODE_E: return 0x1200;
+      case AKEYCODE_F: return 0x2100;
+      case AKEYCODE_G: return 0x2200;
+      case AKEYCODE_H: return 0x2300;
+      case AKEYCODE_I: return 0x1700;
+      case AKEYCODE_J: return 0x2400;
+      case AKEYCODE_K: return 0x2500;
+      case AKEYCODE_L: return 0x2600;
+      case AKEYCODE_M: return 0x3200;
+      case AKEYCODE_N: return 0x3100;
+      case AKEYCODE_O: return 0x1800;
+      case AKEYCODE_P: return 0x1900;
+      case AKEYCODE_Q: return 0x1000;
+      case AKEYCODE_R: return 0x1300;
+      case AKEYCODE_S: return 0x1f00;
+      case AKEYCODE_T: return 0x1400;
+      case AKEYCODE_U: return 0x1600;
+      case AKEYCODE_V: return 0x2f00;
+      case AKEYCODE_W: return 0x1100;
+      case AKEYCODE_X: return 0x2d00;
+      case AKEYCODE_Y: return 0x1500;
+      case AKEYCODE_Z: return 0x2c00;
+
+      case AKEYCODE_0: return 0x8100;
+      case AKEYCODE_1: return 0x7800;
+      case AKEYCODE_2: return 0x7900;
+      case AKEYCODE_3: return 0x7a00;
+      case AKEYCODE_4: return 0x7b00;
+      case AKEYCODE_5: return 0x7c00;
+      case AKEYCODE_6: return 0x7d00;
+      case AKEYCODE_7: return 0x7e00;
+      case AKEYCODE_8: return 0x7f00;
+      case AKEYCODE_9: return 0x8000;
 
       case AKEYCODE_DPAD_UP:    return 0xc800; // Arrow up
       case AKEYCODE_DPAD_DOWN:  return 0xd000; // Arrow down
@@ -19,6 +53,8 @@ namespace {
       case AKEYCODE_DPAD_RIGHT: return 0xcd00; // Arrow right
 
       case AKEYCODE_SPACE:      return 0x3900; // Space
+      case AKEYCODE_ENTER:      return 0x1c00; // Enter
+      case AKEYCODE_DEL:        return 0x0e00; // Backspace
       case AKEYCODE_BUTTON_A:   return 0x3800; // Jump - Alt
       case AKEYCODE_BUTTON_B:   return 0x1d00; // Action - Ctrl
       case AKEYCODE_BUTTON_X:   return 0x3900; // Weapon/Action
@@ -62,28 +98,37 @@ int32_t AndroidInputBackend::onInputEvent(AInputEvent* event) {
   switch(AInputEvent_getType(event)) {
     case AINPUT_EVENT_TYPE_KEY: {
       int32_t code = mapKey(AKeyEvent_getKeyCode(event));
-      if(code!=0 && keyCb) {
+      if(code!=0) {
         bool pressed = (AKeyEvent_getAction(event)==AKEY_EVENT_ACTION_DOWN);
-        keyCb(code, pressed);
+        if(keyCb)
+          keyCb(code, pressed);
+        else
+          LOGI("key %d %s", code, pressed?"down":"up");
         return 1;
         }
       break;
       }
     case AINPUT_EVENT_TYPE_MOTION: {
-      if(motionCb) {
-        const int32_t src = AInputEvent_getSource(event);
-        float x=0.f, y=0.f;
-        if(src & AINPUT_SOURCE_JOYSTICK) {
-          x = AMotionEvent_getAxisValue(reinterpret_cast<AMotionEvent*>(event), AMOTION_EVENT_AXIS_X, 0);
-          y = -AMotionEvent_getAxisValue(reinterpret_cast<AMotionEvent*>(event), AMOTION_EVENT_AXIS_Y, 0);
-        } else if(src & AINPUT_SOURCE_TOUCHSCREEN) {
-          x = AMotionEvent_getX(reinterpret_cast<AMotionEvent*>(event),0);
-          y = AMotionEvent_getY(reinterpret_cast<AMotionEvent*>(event),0);
-        }
+      const int32_t src = AInputEvent_getSource(event);
+      float x=0.f, y=0.f;
+      if(src & (AINPUT_SOURCE_JOYSTICK|AINPUT_SOURCE_GAMEPAD)) {
+        x = AMotionEvent_getAxisValue(reinterpret_cast<AMotionEvent*>(event), AMOTION_EVENT_AXIS_X, 0);
+        y = -AMotionEvent_getAxisValue(reinterpret_cast<AMotionEvent*>(event), AMOTION_EVENT_AXIS_Y, 0);
+        if(motionCb)
+          motionCb(x,y);
+        else
+          LOGI("joy %.2f %.2f", x, y);
+        x = AMotionEvent_getAxisValue(reinterpret_cast<AMotionEvent*>(event), AMOTION_EVENT_AXIS_Z, 0);
+        y = -AMotionEvent_getAxisValue(reinterpret_cast<AMotionEvent*>(event), AMOTION_EVENT_AXIS_RZ, 0);
+      } else if(src & AINPUT_SOURCE_TOUCHSCREEN) {
+        x = AMotionEvent_getX(reinterpret_cast<AMotionEvent*>(event),0);
+        y = AMotionEvent_getY(reinterpret_cast<AMotionEvent*>(event),0);
+      }
+      if(motionCb)
         motionCb(x,y);
-        return 1;
-        }
-      break;
+      else
+        LOGI("motion %.2f %.2f", x, y);
+      return 1;
       }
     }
   return 0;

--- a/backend/android/AndroidInputBackend.h
+++ b/backend/android/AndroidInputBackend.h
@@ -12,7 +12,7 @@ class AndroidInputBackend : public IInputBackend {
     void pollEvents() override;
 
     /// Processes an Android input event. Called from native glue.
-    int32_t onInputEvent(AInputEvent* event);
+    int32_t onInputEvent(AInputEvent* event) override;
 
   private:
     KeyCallback    keyCb;

--- a/backend/android/android_main.cpp
+++ b/backend/android/android_main.cpp
@@ -1,6 +1,5 @@
-#include <android/native_activity.h>
+#include <android_native_app_glue.h>
 #include <android/log.h>
-#include <android/native_window_jni.h>
 
 #include "AndroidInputBackend.h"
 #include "AndroidAudioBackend.h"
@@ -9,12 +8,28 @@
 
 extern "C" void GameMain(IInputBackend&,IAudioBackend&,IFileSystemBackend&,INativeGlue&);
 
-extern "C" void ANativeActivity_onCreate(ANativeActivity* activity,void*,size_t){
-  __android_log_print(ANDROID_LOG_INFO,"OpenGothic","activity created");
-  AndroidInputBackend  input;
-  AndroidAudioBackend  audio;
-  AndroidFileSystemBackend fs(activity->assetManager);
-  AndroidNativeGlue    glue(activity);
-  GameMain(input,audio,fs,glue);
-  }
+extern "C" void android_main(struct android_app* app) {
+    app_dummy();
+    __android_log_print(ANDROID_LOG_INFO,"OpenGothic","android_main started");
 
+    AndroidInputBackend  input;
+    AndroidAudioBackend  audio;
+    AndroidFileSystemBackend fs(app->activity->assetManager);
+    AndroidNativeGlue    glue(app->activity);
+
+    app->onInputEvent = ::onInputEvent;
+
+    GameMain(input,audio,fs,glue);
+
+    int events;
+    android_poll_source* source;
+    while(true) {
+        while(ALooper_pollAll(0,nullptr,&events,(void**)&source) >= 0) {
+            if(source)
+                source->process(app, source);
+            if(app->destroyRequested != 0)
+                return;
+        }
+        input.pollEvents();
+    }
+}


### PR DESCRIPTION
## Summary
- extend `IInputBackend` with Android input forwarding
- implement a richer `AndroidInputBackend` with full key mapping, joystick/touch support and debug logging
- switch Android entry point to `android_native_app_glue`
- link against the glue in the Android build

## Testing
- `cmake -B build -S .` *(fails: glslangValidator required)*

------
https://chatgpt.com/codex/tasks/task_e_68572a7bd77083318b81200522831061