### PR TITLE
Enhance Android input classification

### DIFF
--- a/backend/android/AndroidInputBackend.h
+++ b/backend/android/AndroidInputBackend.h
@@ -6,6 +6,8 @@ enum class InputEventType {
   KEY,
   MOTION,
   SPECIAL,
+  SYSTEM,
+  VIRTUAL,
   UNCLASSIFIED
   };
 
@@ -24,6 +26,10 @@ class AndroidInputBackend : public IInputBackend {
     AndroidInputBackend();
     ~AndroidInputBackend() override;
 
+    /// Enables or disables verbose input logging. Defaults to true in debug
+    /// builds and false otherwise.
+    static void setVerboseLogging(bool v);
+
     void setKeyCallback(KeyCallback cb) override;
     void setMotionCallback(MotionCallback cb) override;
     void pollEvents() override;
@@ -34,5 +40,7 @@ class AndroidInputBackend : public IInputBackend {
   private:
     KeyCallback    keyCb;
     MotionCallback motionCb;
+    InputEventData lastEvent{};
+    static bool    verboseLogging;
   };
 

--- a/docs/android_integration_guide.md
+++ b/docs/android_integration_guide.md
@@ -24,8 +24,11 @@ interfaces implemented in `backend/`.
    - Game code should call `GameMain` instead of `main` when built for Android
      so that platform backends can be injected. Touch handling and asset loading
      can then be implemented on top of the provided interfaces.
-   - Version 2 introduced basic key and motion callbacks. Input events are now
-     classified via `InputEventType` into `KEY`, `MOTION`, `SPECIAL` or
-     `UNCLASSIFIED`. `AndroidInputBackend` normalizes data into a small
-     `InputEventData` structure for logging and internal processing.
+  - Version 2 introduced basic key and motion callbacks. Input events are now
+    classified via `InputEventType` into `KEY`, `MOTION`, `SPECIAL`, `SYSTEM`,
+    `VIRTUAL` or `UNCLASSIFIED`. `AndroidInputBackend` normalizes data into a
+    small `InputEventData` structure for logging and internal processing.
+  - Version 4 adds duplicate filtering and a concise `type=value` logging
+    format for easier debugging. Verbose output can be toggled in development
+    builds via `AndroidInputBackend::setVerboseLogging`.
 


### PR DESCRIPTION
## Summary
- extend `InputEventType` with SYSTEM and VIRTUAL
- add runtime toggle for verbose input logging
- log Android events in key=value format
- filter duplicated or malformed events
- document updated event types and logging

## Testing
- `g++ -std=c++20 -c backend/android/AndroidInputBackend.cpp -I backend -I .` *(fails: `android/input.h` missing)*

------
https://chatgpt.com/codex/tasks/task_e_6857317768508331a666e3be459122d7