### PR TITLE
Improve Android input docs

### DIFF
--- a/backend/android/AndroidInputBackend.cpp
+++ b/backend/android/AndroidInputBackend.cpp
@@ -19,6 +19,7 @@ namespace {
       }
     }
 
+  // Log an input event using a compact JSON style string
   void logEvent(const char* msg, const InputEventData& d) {
     if(!AndroidInputBackend::verboseLogging)
       return;
@@ -32,12 +33,14 @@ namespace {
            d.pressed?"true":"false", d.x, d.y);
     }
 
+  // Returns true if two events carry identical data
   bool sameEvent(const InputEventData& a, const InputEventData& b){
     return a.type==b.type && a.source==b.source && a.deviceId==b.deviceId &&
            a.keyCode==b.keyCode && a.pressed==b.pressed &&
            std::fabs(a.x-b.x)<0.0001f && std::fabs(a.y-b.y)<0.0001f;
     }
 
+  // Validates that coordinates are finite values
   bool validCoords(float x,float y){
     return std::isfinite(x) && std::isfinite(y);
     }

--- a/backend/android/AndroidInputBackend.h
+++ b/backend/android/AndroidInputBackend.h
@@ -3,12 +3,12 @@
 #include <android/input.h>
 
 enum class InputEventType {
-  KEY,         //!< Standard key press or release
-  MOTION,      //!< Touch screen or joystick motion
-  SPECIAL,     //!< Buttons like BACK, MENU or VOLUME
-  SYSTEM,      //!< System level actions such as HOME
-  VIRTUAL,     //!< On screen or emulated controls
-  UNCLASSIFIED //!< Anything that doesn't fit other groups
+  KEY,         //!< Hardware key press or release from keyboard or gamepad
+  MOTION,      //!< Pointer or joystick axis movement
+  SPECIAL,     //!< Navigation keys such as BACK, MENU or VOLUME
+  SYSTEM,      //!< Reserved system actions like HOME or POWER
+  VIRTUAL,     //!< On‑screen or emulated controls
+  UNCLASSIFIED //!< Any event not matching the above groups
   };
 
 struct InputEventData {

--- a/docs/android_integration_guide.md
+++ b/docs/android_integration_guide.md
@@ -29,6 +29,8 @@ interfaces implemented in `backend/`.
     `VIRTUAL` or `UNCLASSIFIED`. `AndroidInputBackend` normalizes data into a
     small `InputEventData` structure for logging and internal processing.
   - Version 4 adds duplicate filtering and switches logging to a JSON style
-    record such as `{ "type": "MOTION", "x": 100, "y": 200 }`. Verbose output
-    can be toggled with `AndroidInputBackend::setVerboseLogging`.
+    record such as `{ "type": "MOTION", "x": 100, "y": 200 }`. Events are
+    validated with `validCoords` and filtered with `sameEvent` before
+    dispatch. Verbose output can be toggled with
+    `AndroidInputBackend::setVerboseLogging`.
 


### PR DESCRIPTION
## Summary
- document input filtering helpers in integration guide
- clarify input event comments
- add comments for `sameEvent` and `validCoords`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68573648bca08331847403df7f6f76d0