### PR TITLE
Add repeatable key detection

### DIFF
--- a/backend/android/AndroidInputBackend.cpp
+++ b/backend/android/AndroidInputBackend.cpp
@@ -41,16 +41,29 @@ namespace {
   void logEvent(const char* msg, const InputEventData& d) {
     if(!AndroidInputBackend::verboseLogging)
       return;
-    if(msg)
-      LOGI("{ \"type\": \"%s\", \"source\": \"%s\", \"dev\": %d, \"key\": %d, \"pressed\": %s, \"x\": %.2f, \"y\": %.2f, \"eventTime\": %llu, \"msg\": \"%s\" }",
-           typeToStr(d.type), sourceToStr(d.source), d.deviceId, d.keyCode,
-           d.pressed?"true":"false", d.x, d.y,
-           static_cast<unsigned long long>(d.eventTime), msg);
-    else
-      LOGI("{ \"type\": \"%s\", \"source\": \"%s\", \"dev\": %d, \"key\": %d, \"pressed\": %s, \"x\": %.2f, \"y\": %.2f, \"eventTime\": %llu }",
-           typeToStr(d.type), sourceToStr(d.source), d.deviceId, d.keyCode,
-           d.pressed?"true":"false", d.x, d.y,
-           static_cast<unsigned long long>(d.eventTime));
+    if(d.type==InputEventType::KEY) {
+      if(msg)
+        LOGI("{ \"type\": \"%s\", \"source\": \"%s\", \"dev\": %d, \"key\": %d, \"pressed\": %s, \"repeatable\": %s, \"x\": %.2f, \"y\": %.2f, \"eventTime\": %llu, \"msg\": \"%s\" }",
+             typeToStr(d.type), sourceToStr(d.source), d.deviceId, d.keyCode,
+             d.pressed?"true":"false", d.repeatable?"true":"false", d.x, d.y,
+             static_cast<unsigned long long>(d.eventTime), msg);
+      else
+        LOGI("{ \"type\": \"%s\", \"source\": \"%s\", \"dev\": %d, \"key\": %d, \"pressed\": %s, \"repeatable\": %s, \"x\": %.2f, \"y\": %.2f, \"eventTime\": %llu }",
+             typeToStr(d.type), sourceToStr(d.source), d.deviceId, d.keyCode,
+             d.pressed?"true":"false", d.repeatable?"true":"false", d.x, d.y,
+             static_cast<unsigned long long>(d.eventTime));
+    } else {
+      if(msg)
+        LOGI("{ \"type\": \"%s\", \"source\": \"%s\", \"dev\": %d, \"key\": %d, \"pressed\": %s, \"x\": %.2f, \"y\": %.2f, \"eventTime\": %llu, \"msg\": \"%s\" }",
+             typeToStr(d.type), sourceToStr(d.source), d.deviceId, d.keyCode,
+             d.pressed?"true":"false", d.x, d.y,
+             static_cast<unsigned long long>(d.eventTime), msg);
+      else
+        LOGI("{ \"type\": \"%s\", \"source\": \"%s\", \"dev\": %d, \"key\": %d, \"pressed\": %s, \"x\": %.2f, \"y\": %.2f, \"eventTime\": %llu }",
+             typeToStr(d.type), sourceToStr(d.source), d.deviceId, d.keyCode,
+             d.pressed?"true":"false", d.x, d.y,
+             static_cast<unsigned long long>(d.eventTime));
+    }
     }
 
   int32_t mapKey(int32_t k){
@@ -176,6 +189,7 @@ int32_t AndroidInputBackend::onInputEvent(AInputEvent* event) {
                       raw==AKEYCODE_VOLUME_UP || raw==AKEYCODE_VOLUME_DOWN);
       d.type       = special ? InputEventType::SPECIAL : InputEventType::KEY;
       d.eventTime  = static_cast<uint64_t>(AKeyEvent_getEventTime(event));
+      d.repeatable = isRepeatableEvent(d);
       if(d.deviceId<0 || rawSrc==0)
         return 0;
 

--- a/backend/android/AndroidInputBackend.h
+++ b/backend/android/AndroidInputBackend.h
@@ -27,6 +27,7 @@ struct InputEventData {
   int32_t          deviceId = 0;
   int32_t          keyCode = 0;
   bool             pressed = false;
+  bool             repeatable = false;
   float            x = 0.f;
   float            y = 0.f;
   uint64_t         eventTime = 0;
@@ -40,6 +41,30 @@ inline bool sameEvent(const InputEventData& a,const InputEventData& b){
 
 inline bool validCoords(float x,float y){
   return std::isfinite(x) && std::isfinite(y);
+  }
+
+/// Determines if a key event can auto-repeat when held down
+inline bool isRepeatableEvent(const InputEventData& d){
+  if(d.source!=InputEventSource::KEYBOARD || d.type!=InputEventType::KEY)
+    return false;
+  switch(d.keyCode){
+    // Letters
+    case 0x1e00: case 0x3000: case 0x2e00: case 0x2000: case 0x1200:
+    case 0x2100: case 0x2200: case 0x2300: case 0x1700: case 0x2400:
+    case 0x2500: case 0x2600: case 0x3200: case 0x3100: case 0x1800:
+    case 0x1900: case 0x1000: case 0x1300: case 0x1f00: case 0x1400:
+    case 0x1600: case 0x2f00: case 0x1100: case 0x2d00: case 0x1500:
+    case 0x2c00:
+    // Numbers
+    case 0x7800: case 0x7900: case 0x7a00: case 0x7b00: case 0x7c00:
+    case 0x7d00: case 0x7e00: case 0x7f00: case 0x8000: case 0x8100:
+    // Arrows and editing
+    case 0xc800: case 0xd000: case 0xcb00: case 0xcd00:
+    case 0x0e00: case 0xd300: case 0x3900: case 0x1c00: case 0x0f00:
+      return true;
+    default:
+      return false;
+    }
   }
 
 class AndroidInputBackend : public IInputBackend {

--- a/docs/android_integration_guide.md
+++ b/docs/android_integration_guide.md
@@ -45,3 +45,7 @@ interfaces implemented in `backend/`.
 flags. These fields help correlate events with engine behavior and diagnose
 suppression of duplicates.
 
+  - Version 6 introduces `isRepeatableEvent()` to detect keys that will
+    auto-repeat when held down. Logged key events now include a
+    `repeatable` field indicating this classification.
+

--- a/tests/input_backend_tests.cpp
+++ b/tests/input_backend_tests.cpp
@@ -24,5 +24,10 @@ int main(){
   assert(validCoords(0.f,0.f));
   assert(!validCoords(NAN,0.f));
   assert(!validCoords(0.f,INFINITY));
+
+  a.keyCode = 0x1e00; // 'A'
+  assert(isRepeatableEvent(a));
+  a.keyCode = 0x1d00; // LCtrl
+  assert(!isRepeatableEvent(a));
   return 0;
 }


### PR DESCRIPTION
## Summary
- track whether keyboard keys are repeatable
- log repeatable flag for key events
- document `isRepeatableEvent`
- test repeatable key helper

## Testing
- `g++ -std=c++17 tests/input_backend_tests.cpp -I./backend/android -I./backend -o tests/test_bin && ./tests/test_bin`

------
https://chatgpt.com/codex/tasks/task_e_68573b7c6ba883319af94e8ae1bf35d6