### PR TITLE
Add portable InputMapper module with JNI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,14 @@ target_link_libraries(${PROJECT_NAME} GothicShaders)
 
 include_directories("game")
 
+# InputMapper module
+file(GLOB INPUTMAPPER_SOURCES
+    "input/*.h"
+    "input/*.cpp")
+add_library(InputMapper STATIC ${INPUTMAPPER_SOURCES})
+target_include_directories(InputMapper PUBLIC input external/regoth_legacy/lib/json)
+
+
 ## submodule dependencies
 
 # edd-dbg

--- a/input/InputEvent.h
+++ b/input/InputEvent.h
@@ -1,0 +1,32 @@
+#pragma once
+#include <cstdint>
+
+#ifdef __ANDROID__
+#include <android/input.h>
+#endif
+
+namespace InputMapper {
+
+enum class EventType {
+  KEY,
+  MOTION
+  };
+
+enum class EventSource {
+  UNKNOWN,
+  TOUCH,
+  MULTITOUCH,
+  KEYBOARD,
+  GAMEPAD
+  };
+
+struct InputEvent {
+  EventType   type = EventType::KEY;
+  EventSource source = EventSource::UNKNOWN;
+  int32_t     code = 0;
+  float       value = 0.f;
+  int64_t     timestamp = 0;
+  };
+
+}
+

--- a/input/InputMapper.cpp
+++ b/input/InputMapper.cpp
@@ -1,0 +1,35 @@
+#include "InputMapper.h"
+#ifdef __ANDROID__
+#include <android/log.h>
+#define LOGI(...) __android_log_print(ANDROID_LOG_INFO,"InputMapper",__VA_ARGS__)
+#else
+#include <cstdio>
+#define LOGI(...) std::fprintf(stderr, __VA_ARGS__)
+#endif
+
+namespace InputMapper {
+
+bool InputMapper::loadProfile(const std::string& name,const std::string& jsonStr){
+  InputProfile p;
+  if(!p.loadFromJson(jsonStr))
+    return false;
+  profiles_[name] = std::move(p);
+  if(!active_)
+    active_ = &profiles_[name];
+  return true;
+}
+
+void InputMapper::setActiveProfile(const std::string& name){
+  auto it = profiles_.find(name);
+  if(it!=profiles_.end())
+    active_ = &it->second;
+}
+
+std::optional<std::string> InputMapper::mapEvent(const InputEvent& ev) const {
+  if(!active_)
+    return std::nullopt;
+  return active_->actionFor(static_cast<int>(ev.source), ev.code);
+}
+
+}
+

--- a/input/InputMapper.h
+++ b/input/InputMapper.h
@@ -1,0 +1,22 @@
+#pragma once
+#include "InputEvent.h"
+#include "InputProfile.h"
+#include <unordered_map>
+#include <memory>
+#include <string>
+
+namespace InputMapper {
+
+class InputMapper {
+  public:
+    bool loadProfile(const std::string& name,const std::string& jsonStr);
+    void setActiveProfile(const std::string& name);
+    std::optional<std::string> mapEvent(const InputEvent& ev) const;
+
+  private:
+    std::unordered_map<std::string,InputProfile> profiles_;
+    const InputProfile* active_ = nullptr;
+  };
+
+}
+

--- a/input/InputMapperJNI.cpp
+++ b/input/InputMapperJNI.cpp
@@ -1,0 +1,36 @@
+#include "InputMapper.h"
+#include <jni.h>
+#include <memory>
+
+
+extern "C" JNIEXPORT jlong JNICALL
+Java_com_example_input_InputMapper_nativeCreate(JNIEnv*, jclass){
+  return reinterpret_cast<jlong>(new InputMapper::InputMapper());
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_example_input_InputMapper_nativeDestroy(JNIEnv*, jclass,jlong ptr){
+  delete reinterpret_cast<InputMapper::InputMapper*>(ptr);
+}
+
+extern "C" JNIEXPORT jboolean JNICALL
+Java_com_example_input_InputMapper_nativeLoadProfile(JNIEnv* env,jclass,jlong ptr,
+                                                     jstring name,jstring json){
+  auto* mapper = reinterpret_cast<InputMapper::InputMapper*>(ptr);
+  const char* n = env->GetStringUTFChars(name,nullptr);
+  const char* j = env->GetStringUTFChars(json,nullptr);
+  bool ok = mapper->loadProfile(n,j);
+  env->ReleaseStringUTFChars(name,n);
+  env->ReleaseStringUTFChars(json,j);
+  return static_cast<jboolean>(ok);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_example_input_InputMapper_nativeSetActiveProfile(JNIEnv* env,jclass,jlong ptr,
+                                                          jstring name){
+  auto* mapper = reinterpret_cast<InputMapper::InputMapper*>(ptr);
+  const char* n = env->GetStringUTFChars(name,nullptr);
+  mapper->setActiveProfile(n);
+  env->ReleaseStringUTFChars(name,n);
+}
+

--- a/input/InputProfile.cpp
+++ b/input/InputProfile.cpp
@@ -1,0 +1,45 @@
+#include "InputProfile.h"
+#include "InputEvent.h"
+#include <nlohmann/json.hpp>
+#ifdef __ANDROID__
+#include <android/log.h>
+#define LOGI(...) __android_log_print(ANDROID_LOG_INFO,"InputMapper",__VA_ARGS__)
+#else
+#include <cstdio>
+#define LOGI(...) std::fprintf(stderr, __VA_ARGS__)
+#endif
+
+using json = nlohmann::json;
+
+namespace InputMapper {
+
+bool InputProfile::loadFromJson(const std::string& jsonStr) {
+  map_.clear();
+  json j;
+  try {
+    j = json::parse(jsonStr);
+  } catch(const std::exception& e) {
+    LOGI("Failed to parse profile: %s", e.what());
+    return false;
+  }
+  for(auto it=j.begin(); it!=j.end(); ++it) {
+    int src = std::stoi(it.key());
+    if(!it->is_object())
+      continue;
+    for(auto a=it->begin(); a!=it->end(); ++a) {
+      int code = std::stoi(a.key());
+      map_[Key{src,code}] = a->get<std::string>();
+    }
+  }
+  return true;
+}
+
+std::optional<std::string> InputProfile::actionFor(int source,int code) const {
+  auto it = map_.find(Key{source,code});
+  if(it!=map_.end())
+    return it->second;
+  return std::nullopt;
+}
+
+}
+

--- a/input/InputProfile.h
+++ b/input/InputProfile.h
@@ -1,0 +1,28 @@
+#pragma once
+#include <string>
+#include <unordered_map>
+#include <optional>
+
+namespace InputMapper {
+
+struct InputEvent;
+
+class InputProfile {
+  public:
+    bool loadFromJson(const std::string& jsonStr);
+    std::optional<std::string> actionFor(int source,int code) const;
+
+  private:
+    struct Key {
+      int source;
+      int code;
+      bool operator==(const Key& other) const noexcept { return source==other.source && code==other.code; }
+      };
+    struct KeyHash {
+      size_t operator()(const Key& k) const noexcept { return (static_cast<size_t>(k.source)<<32) ^ static_cast<size_t>(k.code); }
+      };
+    std::unordered_map<Key,std::string,KeyHash> map_;
+  };
+
+}
+


### PR DESCRIPTION
## Summary
- introduce `InputMapper` library for Android-style input profiles
- implement JSON-based profile loading and event mapping
- provide JNI helpers to control active profile from Java
- integrate module into CMake build

## Testing
- `g++ -std=c++20 -Iinput -I/usr/include -c input/InputMapper.cpp`
- `g++ -std=c++20 -Iinput -I/usr/include -c input/InputProfile.cpp`
- `g++ -std=c++20 -Iinput -I/usr/include -I$JAVA_HOME/include -I$JAVA_HOME/include/linux -c input/InputMapperJNI.cpp`

------
https://chatgpt.com/codex/tasks/task_e_6857470ff3b88331a04415969ac49709