### PR TITLE
Add editable input profiles with feedback overlay

### DIFF
--- a/android_profiles_app/app/src/main/AndroidManifest.xml
+++ b/android_profiles_app/app/src/main/AndroidManifest.xml
@@ -13,5 +13,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".EditProfileActivity"
+            android:exported="false" />
     </application>
 </manifest>

--- a/android_profiles_app/app/src/main/java/com/example/profilesapp/EditProfileActivity.kt
+++ b/android_profiles_app/app/src/main/java/com/example/profilesapp/EditProfileActivity.kt
@@ -1,0 +1,91 @@
+package com.example.profilesapp
+
+import android.os.Bundle
+import android.view.KeyEvent
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.activity.viewModels
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import org.json.JSONObject
+
+class EditProfileActivity : ComponentActivity() {
+    private val viewModel: EditProfileViewModel by viewModels {
+        val name = intent.getStringExtra("name") ?: ""
+        EditProfileViewModel.Factory(application, name)
+    }
+    private lateinit var adapter: MappingAdapter
+    private var bindingIndex: Int = -1
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_edit)
+        adapter = MappingAdapter(viewModel.mappings) { idx ->
+            bindingIndex = idx
+            Toast.makeText(this, "Press a button", Toast.LENGTH_SHORT).show()
+        }
+        val list = findViewById<RecyclerView>(R.id.mappingList)
+        list.layoutManager = LinearLayoutManager(this)
+        list.adapter = adapter
+
+        findViewById<View>(R.id.saveButton).setOnClickListener {
+            if (viewModel.save())
+                Toast.makeText(this, "Saved", Toast.LENGTH_SHORT).show()
+            else
+                Toast.makeText(this, "Failed", Toast.LENGTH_SHORT).show()
+            finish()
+        }
+    }
+
+    override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+        if (bindingIndex >= 0 && event.action == KeyEvent.ACTION_DOWN) {
+            val src = if (event.source and android.view.InputDevice.SOURCE_GAMEPAD == android.view.InputDevice.SOURCE_GAMEPAD) 4 else 3
+            viewModel.updateBinding(bindingIndex, src, event.keyCode)
+            adapter.notifyItemChanged(bindingIndex)
+            bindingIndex = -1
+            return true
+        }
+        return super.dispatchKeyEvent(event)
+    }
+
+    class EditProfileViewModel(val app: android.app.Application, val name: String) : ViewModel() {
+        val manager = ProfileManager(app)
+        val mappings = mutableListOf<MappingAdapter.Mapping>()
+
+        init {
+            manager.ensureDefaults()
+            val file = manager.profileFile(name)
+            if (file.exists()) {
+                val json = JSONObject(file.readText())
+                for (srcKey in json.keys()) {
+                    val inner = json.getJSONObject(srcKey)
+                    for (codeKey in inner.keys()) {
+                        mappings += MappingAdapter.Mapping(inner.getString(codeKey), srcKey.toInt(), codeKey.toInt())
+                    }
+                }
+            }
+        }
+
+        fun updateBinding(idx: Int, src: Int, code: Int) {
+            mappings[idx].source = src
+            mappings[idx].code = code
+        }
+
+        fun save(): Boolean {
+            val root = JSONObject()
+            for (m in mappings) {
+                val obj = root.optJSONObject(m.source.toString()) ?: JSONObject().also { root.put(m.source.toString(), it) }
+                obj.put(m.code.toString(), m.action)
+            }
+            return manager.saveProfile(name, root.toString())
+        }
+
+        class Factory(private val app: android.app.Application, private val name: String) : ViewModelProvider.Factory {
+            override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                return EditProfileViewModel(app, name) as T
+            }
+        }
+    }
+}

--- a/android_profiles_app/app/src/main/java/com/example/profilesapp/InputMapper.kt
+++ b/android_profiles_app/app/src/main/java/com/example/profilesapp/InputMapper.kt
@@ -1,7 +1,8 @@
 package com.example.profilesapp
 
-import android.content.Context
 import android.util.Log
+import android.view.InputDevice
+import android.view.KeyEvent
 
 class InputMapper {
     private var nativePtr: Long = nativeCreate()
@@ -15,6 +16,11 @@ class InputMapper {
         Log.i("InputMapper", "Activated profile $id")
     }
 
+    fun mapKeyEvent(event: KeyEvent): String? {
+        val src = if (event.source and InputDevice.SOURCE_GAMEPAD == InputDevice.SOURCE_GAMEPAD) 4 else 3
+        return nativeMapEvent(nativePtr, src, event.keyCode)
+    }
+
     fun destroy() {
         nativeDestroy(nativePtr)
     }
@@ -23,6 +29,7 @@ class InputMapper {
     private external fun nativeDestroy(ptr: Long)
     private external fun nativeLoadProfile(ptr: Long, path: String): Boolean
     private external fun nativeActivateProfile(ptr: Long, id: String)
+    private external fun nativeMapEvent(ptr: Long, source: Int, code: Int): String?
 
     companion object {
         init {

--- a/android_profiles_app/app/src/main/java/com/example/profilesapp/MainActivity.kt
+++ b/android_profiles_app/app/src/main/java/com/example/profilesapp/MainActivity.kt
@@ -1,13 +1,14 @@
 package com.example.profilesapp
 
 import android.os.Bundle
-import android.util.Log
-import java.io.File
+import android.view.KeyEvent
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.viewModels
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import android.content.Intent
 
 class MainActivity : ComponentActivity() {
     private val viewModel: ProfileViewModel by viewModels()
@@ -17,22 +18,37 @@ class MainActivity : ComponentActivity() {
         setContentView(R.layout.activity_main)
 
         val active = findViewById<android.widget.TextView>(R.id.activeProfile)
+        val overlay = findViewById<android.widget.TextView>(R.id.actionOverlay)
         val recycler = findViewById<RecyclerView>(R.id.profileList)
         recycler.layoutManager = LinearLayoutManager(this)
 
-        val profiles = assets.list("profiles")?.toList() ?: emptyList()
-        val adapter = ProfileAdapter(profiles) { name ->
-            val path = File(filesDir, name).also { out ->
-                assets.open("profiles/$name").use { input ->
-                    out.outputStream().use { input.copyTo(it) }
-                }
-            }
-            viewModel.selectProfile(path.path, name)
-        }
+        val adapter = ProfileAdapter(emptyList(), { name ->
+            viewModel.selectProfile(name)
+        }, { name ->
+            val intent = Intent(this, EditProfileActivity::class.java)
+            intent.putExtra("name", name)
+            startActivity(intent)
+        })
         recycler.adapter = adapter
 
         viewModel.activeProfile.observe(this, Observer { p ->
             active.text = "Active: $p"
         })
+
+        viewModel.profiles.observe(this, Observer { list ->
+            adapter.update(list)
+        })
+
+        viewModel.message.observe(this, Observer { msg ->
+            Toast.makeText(this, msg, Toast.LENGTH_SHORT).show()
+            overlay.text = msg
+            overlay.visibility = android.view.View.VISIBLE
+            overlay.postDelayed({ overlay.visibility = android.view.View.GONE }, 500)
+        })
+    }
+
+    override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+        viewModel.mapKey(event)
+        return super.dispatchKeyEvent(event)
     }
 }

--- a/android_profiles_app/app/src/main/java/com/example/profilesapp/MappingAdapter.kt
+++ b/android_profiles_app/app/src/main/java/com/example/profilesapp/MappingAdapter.kt
@@ -1,0 +1,35 @@
+package com.example.profilesapp
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+
+class MappingAdapter(
+    private val items: MutableList<Mapping>,
+    private val onBindRequest: (Int) -> Unit
+) : RecyclerView.Adapter<MappingAdapter.VH>() {
+
+    data class Mapping(var action: String, var source: Int, var code: Int)
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VH {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(android.R.layout.simple_list_item_2, parent, false)
+        return VH(view)
+    }
+
+    override fun onBindViewHolder(holder: VH, position: Int) {
+        val m = items[position]
+        holder.text1.text = m.action
+        holder.text2.text = "${m.source}:${m.code}"
+        holder.itemView.setOnClickListener { onBindRequest(position) }
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    class VH(view: View) : RecyclerView.ViewHolder(view) {
+        val text1: TextView = view.findViewById(android.R.id.text1)
+        val text2: TextView = view.findViewById(android.R.id.text2)
+    }
+}

--- a/android_profiles_app/app/src/main/java/com/example/profilesapp/ProfileAdapter.kt
+++ b/android_profiles_app/app/src/main/java/com/example/profilesapp/ProfileAdapter.kt
@@ -6,9 +6,11 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 
-class ProfileAdapter(private val items: List<String>,
-                     private val onClick: (String) -> Unit) :
-    RecyclerView.Adapter<ProfileAdapter.VH>() {
+class ProfileAdapter(
+    private var items: List<String>,
+    private val onClick: (String) -> Unit,
+    private val onLongClick: (String) -> Unit = {}
+) : RecyclerView.Adapter<ProfileAdapter.VH>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VH {
         val view = LayoutInflater.from(parent.context)
@@ -19,9 +21,18 @@ class ProfileAdapter(private val items: List<String>,
     override fun onBindViewHolder(holder: VH, position: Int) {
         holder.text.text = items[position]
         holder.itemView.setOnClickListener { onClick(items[position]) }
+        holder.itemView.setOnLongClickListener {
+            onLongClick(items[position])
+            true
+        }
     }
 
     override fun getItemCount(): Int = items.size
+
+    fun update(newItems: List<String>) {
+        items = newItems
+        notifyDataSetChanged()
+    }
 
     class VH(view: View) : RecyclerView.ViewHolder(view) {
         val text: TextView = view.findViewById(android.R.id.text1)

--- a/android_profiles_app/app/src/main/java/com/example/profilesapp/ProfileManager.kt
+++ b/android_profiles_app/app/src/main/java/com/example/profilesapp/ProfileManager.kt
@@ -1,0 +1,33 @@
+package com.example.profilesapp
+
+import android.content.Context
+import java.io.File
+
+class ProfileManager(private val context: Context) {
+    private val dir: File = File(context.filesDir, "profiles").apply { mkdirs() }
+
+    fun ensureDefaults() {
+        val names = context.assets.list("profiles") ?: return
+        for (n in names) {
+            val out = File(dir, n)
+            if (!out.exists()) {
+                context.assets.open("profiles/$n").use { input ->
+                    out.outputStream().use { input.copyTo(it) }
+                }
+            }
+        }
+    }
+
+    fun listProfiles(): List<String> = dir.list()?.toList() ?: emptyList()
+
+    fun profileFile(name: String): File = File(dir, name)
+
+    fun saveProfile(name: String, json: String): Boolean {
+        return try {
+            profileFile(name).writeText(json)
+            true
+        } catch (e: Exception) {
+            false
+        }
+    }
+}

--- a/android_profiles_app/app/src/main/java/com/example/profilesapp/ProfileViewModel.kt
+++ b/android_profiles_app/app/src/main/java/com/example/profilesapp/ProfileViewModel.kt
@@ -3,17 +3,38 @@ package com.example.profilesapp
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.MutableLiveData
-import java.io.File
+import android.view.KeyEvent
 
 class ProfileViewModel(application: Application) : AndroidViewModel(application) {
     val activeProfile = MutableLiveData<String>()
+    val profiles = MutableLiveData<List<String>>()
+    val message = MutableLiveData<String>()
     private val mapper = InputMapper()
+    private val manager = ProfileManager(application)
 
-    fun selectProfile(path: String, name: String) {
-        if (mapper.loadProfile(path)) {
+    init {
+        manager.ensureDefaults()
+        refresh()
+    }
+
+    private fun refresh() {
+        profiles.postValue(manager.listProfiles())
+    }
+
+    fun selectProfile(name: String) {
+        val file = manager.profileFile(name)
+        if (mapper.loadProfile(file.path)) {
             mapper.activateProfile(name)
             activeProfile.postValue(name)
+        } else {
+            message.postValue("Failed to load $name")
         }
+    }
+
+    fun mapKey(event: KeyEvent): String? {
+        val res = mapper.mapKeyEvent(event)
+        if (res != null) message.postValue(res)
+        return res
     }
 
     override fun onCleared() {

--- a/android_profiles_app/app/src/main/res/layout/activity_edit.xml
+++ b/android_profiles_app/app/src/main/res/layout/activity_edit.xml
@@ -4,24 +4,16 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <TextView
-        android:id="@+id/activeProfile"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="Active: none" />
-
     <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/profileList"
+        android:id="@+id/mappingList"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1" />
 
-    <TextView
-        android:id="@+id/actionOverlay"
+    <Button
+        android:id="@+id/saveButton"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="8dp"
-        android:textColor="#FFFFFF"
-        android:background="#66000000"
-        android:visibility="gone" />
+        android:text="Save" />
+
 </LinearLayout>

--- a/input/InputMapperJNI.cpp
+++ b/input/InputMapperJNI.cpp
@@ -63,3 +63,17 @@ Java_com_example_profilesapp_InputMapper_nativeActivateProfile(JNIEnv* env,jobje
   mapper->setActiveProfile(n);
   env->ReleaseStringUTFChars(name,n);
 }
+
+extern "C" JNIEXPORT jstring JNICALL
+Java_com_example_profilesapp_InputMapper_nativeMapEvent(JNIEnv* env,jobject,jlong ptr,
+                                                        jint source,jint code){
+  auto* mapper = reinterpret_cast<InputMapper::InputMapper*>(ptr);
+  InputMapper::InputEvent ev;
+  ev.type   = InputMapper::EventType::KEY;
+  ev.source = static_cast<InputMapper::EventSource>(source);
+  ev.code   = code;
+  auto res = mapper->mapEvent(ev);
+  if(!res)
+    return nullptr;
+  return env->NewStringUTF(res->c_str());
+}


### PR DESCRIPTION
## Summary
- implement `ProfileManager` for loading and saving JSON profiles
- add `EditProfileActivity` with `MappingAdapter` to rebind keys
- update `ProfileViewModel`/`MainActivity` to use new manager and show overlay
- extend `InputMapperJNI` with `nativeMapEvent`
- layouts updated for action overlay and edit screen

## Testing
- `gradle assembleDebug` *(fails: SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_68574ab1de788331ad7663b7eba7ac8a