### PR TITLE
Implement profile manager features

### DIFF
--- a/android_profiles_app/app/build.gradle
+++ b/android_profiles_app/app/build.gradle
@@ -7,6 +7,8 @@ android {
     namespace 'com.example.profilesapp'
     compileSdk 34
 
+    ndkVersion '26.2.11394342'
+
     defaultConfig {
         applicationId 'com.example.profilesapp'
         minSdk 24
@@ -32,6 +34,10 @@ android {
         cmake {
             path "src/main/cpp/CMakeLists.txt"
         }
+    }
+
+    buildFeatures {
+        prefab true
     }
 }
 

--- a/android_profiles_app/app/src/main/java/com/example/profilesapp/MainActivity.kt
+++ b/android_profiles_app/app/src/main/java/com/example/profilesapp/MainActivity.kt
@@ -2,7 +2,15 @@ package com.example.profilesapp
 
 import android.os.Bundle
 import android.view.KeyEvent
+import android.view.Menu
+import android.view.MenuItem
+import android.view.inputmethod.InputMethodManager
 import android.widget.Toast
+import android.hardware.input.InputManager
+import android.view.InputDevice
+import android.os.Environment
+import android.app.Activity
+import android.provider.Settings
 import androidx.activity.ComponentActivity
 import androidx.activity.viewModels
 import androidx.lifecycle.Observer
@@ -12,15 +20,34 @@ import android.content.Intent
 
 class MainActivity : ComponentActivity() {
     private val viewModel: ProfileViewModel by viewModels()
+    private val REQ_IMPORT = 1001
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
+        if(!Settings.canDrawOverlays(this)) {
+            val perm = Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION)
+            startActivity(perm)
+            Toast.makeText(this, "Grant overlay permission", Toast.LENGTH_LONG).show()
+        }
+
         val active = findViewById<android.widget.TextView>(R.id.activeProfile)
         val overlay = findViewById<android.widget.TextView>(R.id.actionOverlay)
         val recycler = findViewById<RecyclerView>(R.id.profileList)
+        val noHw = findViewById<android.widget.TextView>(R.id.noHardwareMessage)
         recycler.layoutManager = LinearLayoutManager(this)
+
+        val inputManager = getSystemService(InputManager::class.java)
+        val hasHw = inputManager.inputDeviceIds.any { id ->
+            inputManager.getInputDevice(id)?.let { d ->
+                val src = d.sources
+                (src and InputDevice.SOURCE_GAMEPAD == InputDevice.SOURCE_GAMEPAD) ||
+                        (src and InputDevice.SOURCE_KEYBOARD == InputDevice.SOURCE_KEYBOARD)
+            } ?: false
+        }
+        recycler.visibility = if (hasHw) android.view.View.VISIBLE else android.view.View.GONE
+        noHw.visibility = if (hasHw) android.view.View.GONE else android.view.View.VISIBLE
 
         val adapter = ProfileAdapter(emptyList(), { name ->
             viewModel.selectProfile(name)
@@ -50,5 +77,44 @@ class MainActivity : ComponentActivity() {
     override fun dispatchKeyEvent(event: KeyEvent): Boolean {
         viewModel.mapKey(event)
         return super.dispatchKeyEvent(event)
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        menuInflater.inflate(R.menu.main_menu, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when(item.itemId) {
+            R.id.menu_import -> {
+                val intent = android.content.Intent(android.content.Intent.ACTION_OPEN_DOCUMENT).apply {
+                    addCategory(android.content.Intent.CATEGORY_OPENABLE)
+                    type = "application/json"
+                }
+                startActivityForResult(intent, REQ_IMPORT)
+                true
+            }
+            R.id.menu_export -> {
+                val dir = getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS) ?: cacheDir
+                val ok = viewModel.exportProfiles(dir)
+                val msg = if(ok) "Exported to ${dir.absolutePath}" else "Export failed"
+                Toast.makeText(this, msg, Toast.LENGTH_LONG).show()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if(requestCode == REQ_IMPORT && resultCode == Activity.RESULT_OK) {
+            data?.data?.let { uri ->
+                contentResolver.openInputStream(uri)?.use { input ->
+                    val ok = viewModel.importProfile(uri, input)
+                    val msg = if(ok) "Imported" else "Import failed"
+                    Toast.makeText(this, msg, Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
     }
 }

--- a/android_profiles_app/app/src/main/java/com/example/profilesapp/ProfileViewModel.kt
+++ b/android_profiles_app/app/src/main/java/com/example/profilesapp/ProfileViewModel.kt
@@ -5,6 +5,12 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.MutableLiveData
 import android.view.KeyEvent
 import android.view.MotionEvent
+import android.hardware.input.InputManager
+import android.content.Context
+import android.view.InputDevice
+import android.net.Uri
+import java.io.File
+import java.io.InputStream
 
 class ProfileViewModel(application: Application) : AndroidViewModel(application) {
     val activeProfile = MutableLiveData<String>()
@@ -15,7 +21,25 @@ class ProfileViewModel(application: Application) : AndroidViewModel(application)
 
     init {
         manager.ensureDefaults()
+        autoLoadDefault()
         refresh()
+    }
+
+    private fun autoLoadDefault() {
+        val ctx = getApplication<Application>()
+        val im = ctx.getSystemService(Context.INPUT_SERVICE) as InputManager
+        val hasGamepad = im.inputDeviceIds.any { id ->
+            im.getInputDevice(id)?.sources?.let { s ->
+                s and InputDevice.SOURCE_GAMEPAD == InputDevice.SOURCE_GAMEPAD
+            } ?: false
+        }
+        val profile = if(hasGamepad) "alt.json" else "default.json"
+        val file = manager.profileFile(profile)
+        if(file.exists()) {
+            mapper.loadProfile(file.path)
+            mapper.activateProfile(profile)
+            activeProfile.postValue(profile)
+        }
     }
 
     private fun refresh() {
@@ -43,6 +67,18 @@ class ProfileViewModel(application: Application) : AndroidViewModel(application)
         val res = mapper.mapMotionEvent(event.source, axis, event.getAxisValue(axis))
         if (res != null) message.postValue(res)
         return res
+    }
+
+    fun exportProfiles(dir: File): Boolean {
+        val ok = manager.exportProfiles(dir)
+        if(ok) refresh()
+        return ok
+    }
+
+    fun importProfile(uri: Uri, input: InputStream): Boolean {
+        val ok = manager.importProfile(uri, input)
+        if(ok) refresh()
+        return ok
     }
 
     override fun onCleared() {

--- a/android_profiles_app/app/src/main/res/layout/activity_main.xml
+++ b/android_profiles_app/app/src/main/res/layout/activity_main.xml
@@ -17,6 +17,14 @@
         android:layout_weight="1" />
 
     <TextView
+        android:id="@+id/noHardwareMessage"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="No input hardware detected"
+        android:gravity="center"
+        android:visibility="gone" />
+
+    <TextView
         android:id="@+id/actionOverlay"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/android_profiles_app/app/src/main/res/menu/main_menu.xml
+++ b/android_profiles_app/app/src/main/res/menu/main_menu.xml
@@ -1,0 +1,4 @@
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:id="@+id/menu_import" android:title="Import Profile" />
+    <item android:id="@+id/menu_export" android:title="Export Profiles" />
+</menu>

--- a/android_profiles_app/local.properties
+++ b/android_profiles_app/local.properties
@@ -1,0 +1,2 @@
+sdk.dir=/opt/android-sdk
+ndk.dir=/opt/android-ndk


### PR DESCRIPTION
## Summary
- implement auto loading of controller/phone profiles
- add export and import actions in MainActivity
- show fallback UI when no input hardware detected
- request overlay permission on start
- update build config for NDK build
- add Android SDK/NDK paths in `local.properties`

## Testing
- `gradle -p android_profiles_app assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685752e54de88331b934ce81172012f0