### PR TITLE
Add optional OpenXR skeleton

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,14 @@ set(CMAKE_SKIP_RPATH ON)
 
 add_executable(${PROJECT_NAME})
 
+option(OPENXR_ENABLED "Enable OpenXR support" OFF)
+if(OPENXR_ENABLED)
+  find_package(OpenXR REQUIRED)
+  target_sources(${PROJECT_NAME} PRIVATE src/xr/XR.cpp src/xr/OpenXRBackend.cpp)
+  target_link_libraries(${PROJECT_NAME} OpenXR::openxr_loader)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE OPENXR_ENABLED)
+endif()
+
 if(MSVC)
   add_definitions(-D_USE_MATH_DEFINES)
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
@@ -82,6 +90,7 @@ add_subdirectory(shader)
 target_link_libraries(${PROJECT_NAME} GothicShaders)
 
 include_directories("game")
+include_directories("include")
 
 ## submodule dependencies
 

--- a/game/commandline.cpp
+++ b/game/commandline.cpp
@@ -142,6 +142,9 @@ CommandLine::CommandLine(int argc, const char** argv) {
       if(i<argc)
         isRtSm = (std::string_view(argv[i])!="0" && std::string_view(argv[i])!="false");
       }
+    else if(arg=="--vr" || arg=="-vr") {
+      vr = true;
+      }
     else {
       Log::i("unreacognized commandline option: \"", arg, "\"");
       }
@@ -214,6 +217,10 @@ std::u16string CommandLine::cutscenePath(ScriptLang lang) const {
 
 std::u16string CommandLine::nestedPath(const std::initializer_list<const char16_t*>& name, Tempest::Dir::FileType type) const {
   return FileUtil::nestedPath(gpath, name, type);
+  }
+
+bool CommandLine::isVr() const {
+  return vr;
   }
 
 bool CommandLine::validateGothicPath() const {

--- a/game/commandline.h
+++ b/game/commandline.h
@@ -47,6 +47,7 @@ class CommandLine {
     bool                doForceG2()        const { return forceG2;      }
     bool                doForceG2NR()      const { return forceG2NR;    }
     bool                aaPreset()         const { return aaPresetId;   }
+    bool                isVr()            const;
     std::string_view    defaultSave()      const { return saveDef;    }
 
     std::string         wrldDef;
@@ -79,5 +80,6 @@ class CommandLine {
     bool                forceG2      = false;
     bool                forceG2NR    = false;
     uint32_t            aaPresetId = 0;
+    bool                vr          = false;
   };
 

--- a/game/main.cpp
+++ b/game/main.cpp
@@ -23,6 +23,7 @@
 #include "gothic.h"
 #include "build.h"
 #include "commandline.h"
+#include <xr/XR.h>
 
 #include <dmusic.h>
 
@@ -135,12 +136,22 @@ int main(int argc,const char** argv) {
   Tempest::Device      device{*api,gpuName};
   CrashLog::setGpu(device.properties().name);
 
+  XR xr;
+  IXRBackend* xrBackend = nullptr;
+#ifdef OPENXR_ENABLED
+  if(cmd.isVr()) {
+    Tempest::Window tmp;
+    if(xr.initialize(device,tmp))
+      xrBackend = xr.backend();
+  }
+#endif
+
   Resources            resources{device};
   Gothic               gothic;
   GameMusic            music;
   gothic.setupGlobalScripts();
 
-  MainWindow           wx(device);
+  MainWindow           wx(device, xrBackend);
   Tempest::Application app;
   return app.exec();
   }

--- a/game/mainwindow.cpp
+++ b/game/mainwindow.cpp
@@ -28,8 +28,8 @@
 
 using namespace Tempest;
 
-MainWindow::MainWindow(Device& device)
-  : Window(Maximized),device(device),swapchain(device,hwnd()),
+MainWindow::MainWindow(Device& device, IXRBackend* xr)
+  : Window(Maximized),device(device),xrBackend_(xr),swapchain(device,hwnd()),
     atlas(device),renderer(swapchain),
     rootMenu(keycodec),inventory(keycodec),
     dialogs(inventory),document(keycodec),
@@ -120,6 +120,8 @@ MainWindow::MainWindow(Device& device)
 MainWindow::~MainWindow() {
   GameMusic::inst().stopMusic();
   Gothic::inst().cancelLoading();
+  if(xrBackend_)
+    xrBackend_->shutdown();
   device.waitIdle();
   takeWidget(&dialogs);
   takeWidget(&inventory);
@@ -1166,6 +1168,12 @@ void MainWindow::render(){
     const uint64_t dt = tick();
     updateAnimation(dt);
     tickCamera(dt);
+
+    if(xrBackend_!=nullptr) {
+      if(xrBackend_->beginFrame())
+        xrBackend_->endFrame();
+      return;
+      }
 
     auto& sync = fence[cmdId];
     if(!sync.wait(0)) {

--- a/game/mainwindow.h
+++ b/game/mainwindow.h
@@ -34,6 +34,7 @@
 #include "ui/menuroot.h"
 #include "ui/consolewidget.h"
 #include "ui/touchinput.h"
+#include <xr/IXRBackend.h>
 
 #include "utils/keycodec.h"
 #include "resources.h"
@@ -44,7 +45,7 @@ class Interactive;
 
 class MainWindow : public Tempest::Window {
   public:
-    explicit MainWindow(Tempest::Device& device);
+    explicit MainWindow(Tempest::Device& device, IXRBackend* xr);
     ~MainWindow() override;
 
     float uiScale() const;
@@ -113,6 +114,7 @@ class MainWindow : public Tempest::Window {
       };
 
     Tempest::Device&      device;
+    IXRBackend*           xrBackend_ = nullptr;
     Tempest::Swapchain    swapchain;
     Tempest::TextureAtlas atlas;
     Tempest::Font         font;

--- a/include/xr/IXRBackend.h
+++ b/include/xr/IXRBackend.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <array>
+namespace Tempest { class Device; class Window; }
+struct EyeInfo {
+  // Placeholder for P2 (per-eye view/proj + Tempest attachments)
+  // For P1 leave empty; provide size() via views()
+};
+class IXRBackend {
+public:
+  virtual ~IXRBackend() = default;
+  virtual bool initialize(Tempest::Device& dev, Tempest::Window& win) = 0;
+  virtual void shutdown() = 0;
+  virtual bool beginFrame() = 0;
+  virtual void endFrame() = 0;
+  virtual std::array<EyeInfo,2> views() const = 0; // returns default/empty at P1
+};

--- a/include/xr/XR.h
+++ b/include/xr/XR.h
@@ -1,0 +1,12 @@
+#pragma once
+class IXRBackend;
+namespace Tempest { class Device; class Window; }
+class XR {
+public:
+  XR();
+  ~XR();
+  bool initialize(Tempest::Device& dev, Tempest::Window& win); // returns true if backend active
+  IXRBackend* backend() const;
+private:
+  IXRBackend* impl_; // owned
+};

--- a/src/xr/OpenXRBackend.cpp
+++ b/src/xr/OpenXRBackend.cpp
@@ -1,0 +1,102 @@
+#ifdef OPENXR_ENABLED
+#include "OpenXRBackend.h"
+#include <Tempest/Log>
+#include <cstring>
+
+OpenXRBackend::OpenXRBackend() = default;
+OpenXRBackend::~OpenXRBackend() {
+  shutdown();
+}
+
+bool OpenXRBackend::initialize(Tempest::Device& dev, Tempest::Window& win) {
+  (void)dev;
+  (void)win;
+  XrInstanceCreateInfo ici{XR_TYPE_INSTANCE_CREATE_INFO};
+  std::strcpy(ici.applicationInfo.applicationName, "OpenGothic");
+  std::strcpy(ici.applicationInfo.engineName, "OpenGothic");
+  ici.applicationInfo.apiVersion = XR_CURRENT_API_VERSION;
+  if(xrCreateInstance(&ici,&instance)!=XR_SUCCESS) {
+    Tempest::Log::e("xrCreateInstance failed");
+    return false;
+  }
+
+  XrInstanceProperties ip{XR_TYPE_INSTANCE_PROPERTIES};
+  if(xrGetInstanceProperties(instance,&ip)==XR_SUCCESS) {
+    Tempest::Log::i("OpenXR runtime: ", ip.runtimeName);
+  }
+
+  XrSystemGetInfo sgi{XR_TYPE_SYSTEM_GET_INFO};
+  sgi.formFactor = XR_FORM_FACTOR_HEAD_MOUNTED_DISPLAY;
+  if(xrGetSystem(instance,&sgi,&systemId)!=XR_SUCCESS) {
+    Tempest::Log::e("xrGetSystem failed");
+    xrDestroyInstance(instance);
+    instance = XR_NULL_HANDLE;
+    return false;
+  }
+
+  XrSessionCreateInfo sci{XR_TYPE_SESSION_CREATE_INFO};
+  sci.systemId = systemId;
+  sci.next = nullptr; // no graphics binding for now
+  if(xrCreateSession(instance,&sci,&session)!=XR_SUCCESS) {
+    Tempest::Log::e("xrCreateSession failed");
+    xrDestroyInstance(instance);
+    instance = XR_NULL_HANDLE;
+    return false;
+  }
+
+  XrReferenceSpaceCreateInfo rs{XR_TYPE_REFERENCE_SPACE_CREATE_INFO};
+  rs.referenceSpaceType = XR_REFERENCE_SPACE_TYPE_LOCAL;
+  rs.poseInReferenceSpace.orientation.w = 1.f;
+  if(xrCreateReferenceSpace(session,&rs,&space)!=XR_SUCCESS) {
+    Tempest::Log::e("xrCreateReferenceSpace failed");
+    xrDestroySession(session);
+    xrDestroyInstance(instance);
+    session = XR_NULL_HANDLE;
+    instance = XR_NULL_HANDLE;
+    return false;
+  }
+
+  Tempest::Log::i("View configuration: PRIMARY_STEREO");
+  return true;
+}
+
+void OpenXRBackend::shutdown() {
+  if(space!=XR_NULL_HANDLE) {
+    xrDestroySpace(space);
+    space = XR_NULL_HANDLE;
+  }
+  if(session!=XR_NULL_HANDLE) {
+    xrDestroySession(session);
+    session = XR_NULL_HANDLE;
+  }
+  if(instance!=XR_NULL_HANDLE) {
+    xrDestroyInstance(instance);
+    instance = XR_NULL_HANDLE;
+  }
+}
+
+bool OpenXRBackend::beginFrame() {
+  if(session==XR_NULL_HANDLE)
+    return false;
+  XrFrameWaitInfo wi{XR_TYPE_FRAME_WAIT_INFO};
+  if(xrWaitFrame(session,&wi,&frameState)!=XR_SUCCESS)
+    return false;
+  XrFrameBeginInfo bi{XR_TYPE_FRAME_BEGIN_INFO};
+  return xrBeginFrame(session,&bi)==XR_SUCCESS;
+}
+
+void OpenXRBackend::endFrame() {
+  if(session==XR_NULL_HANDLE)
+    return;
+  XrFrameEndInfo ei{XR_TYPE_FRAME_END_INFO};
+  ei.displayTime = frameState.predictedDisplayTime;
+  ei.environmentBlendMode = XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
+  ei.layerCount = 0;
+  ei.layers = nullptr;
+  xrEndFrame(session,&ei);
+}
+
+std::array<EyeInfo,2> OpenXRBackend::views() const {
+  return {};
+}
+#endif

--- a/src/xr/OpenXRBackend.h
+++ b/src/xr/OpenXRBackend.h
@@ -1,0 +1,26 @@
+#pragma once
+#ifdef OPENXR_ENABLED
+#include <xr/IXRBackend.h>
+#include <openxr/openxr.h>
+#include <openxr/openxr_platform.h>
+#include <array>
+
+class OpenXRBackend : public IXRBackend {
+public:
+  OpenXRBackend();
+  ~OpenXRBackend() override;
+
+  bool initialize(Tempest::Device& dev, Tempest::Window& win) override;
+  void shutdown() override;
+  bool beginFrame() override;
+  void endFrame() override;
+  std::array<EyeInfo,2> views() const override;
+
+private:
+  XrInstance    instance = XR_NULL_HANDLE;
+  XrSystemId    systemId = XR_NULL_SYSTEM_ID;
+  XrSession     session  = XR_NULL_HANDLE;
+  XrSpace       space    = XR_NULL_HANDLE;
+  XrFrameState  frameState{XR_TYPE_FRAME_STATE};
+};
+#endif

--- a/src/xr/XR.cpp
+++ b/src/xr/XR.cpp
@@ -1,0 +1,33 @@
+#include <xr/XR.h>
+#include <xr/IXRBackend.h>
+
+#ifdef OPENXR_ENABLED
+#include "OpenXRBackend.h"
+#endif
+
+XR::XR() : impl_(nullptr) {
+}
+
+XR::~XR() {
+  if(impl_) {
+    impl_->shutdown();
+    delete impl_;
+  }
+}
+
+bool XR::initialize(Tempest::Device& dev, Tempest::Window& win) {
+#ifdef OPENXR_ENABLED
+  if(impl_==nullptr) {
+    impl_ = new OpenXRBackend();
+    if(!impl_->initialize(dev,win)) {
+      delete impl_;
+      impl_ = nullptr;
+    }
+  }
+#endif
+  return impl_!=nullptr;
+}
+
+IXRBackend* XR::backend() const {
+  return impl_;
+}


### PR DESCRIPTION
## Summary
- add optional OpenXR build and source wiring
- parse `--vr` flag and plumb backend pointer through main window
- introduce basic OpenXR backend with frame loop

## Testing
- `cmake -S . -B build` *(fails: glslangValidator required)*

------
https://chatgpt.com/codex/tasks/task_e_68c5aeea3980833191057c9fb5a8ca3a