### PR TITLE
Add head-tracked VR camera

### DIFF
--- a/README_VR.md
+++ b/README_VR.md
@@ -1,0 +1,10 @@
+# VR Notes
+
+Run the game with `--vr` to enable the OpenXR backend.
+
+### Options
+* `--vr-first-person=on|off` – toggle first person camera (default `on`).
+* `--vr-height-offset=<m>` – vertical eye offset in meters (default `1.75`).
+* `--vr-allow-roll=on|off` – allow roll from the headset (default `off`).
+
+Keyboard, mouse and gamepad remain for movement and turning.

--- a/game/camera.cpp
+++ b/game/camera.cpp
@@ -256,7 +256,19 @@ void Camera::onRotateMouse(const PointF& dpos) {
   dst.spin.y += dpos.y;
   }
 
+void Camera::setExternalViewProj(const Matrix4x4* view, const Matrix4x4* proj) {
+  extView = view;
+  extProj = proj;
+  }
+
+void Camera::clearExternalViewProj() {
+  extView = nullptr;
+  extProj = nullptr;
+  }
+
 Matrix4x4 Camera::projective() const {
+  if(extProj!=nullptr)
+    return *extProj;
   auto ret = proj;
   if(auto w = Gothic::inst().world())
     w->globalFx()->morph(ret);
@@ -917,6 +929,8 @@ Matrix4x4 Camera::viewProj() const {
   }
 
 Matrix4x4 Camera::view() const {
+  if(extView!=nullptr)
+    return *extView;
   auto spin = src.spin+offsetAng;
   return mkView(origin,spin);
   }

--- a/game/camera.h
+++ b/game/camera.h
@@ -100,6 +100,9 @@ class Camera final {
 
     void               onRotateMouse(const Tempest::PointF& dpos);
 
+    void               setExternalViewProj(const Tempest::Matrix4x4* view, const Tempest::Matrix4x4* proj);
+    void               clearExternalViewProj();
+
     Tempest::Matrix4x4 projective() const;
     Tempest::Matrix4x4 view() const;
     Tempest::Matrix4x4 viewProj() const;
@@ -147,6 +150,9 @@ class Camera final {
     uint32_t              vpWidth=0;
     uint32_t              vpHeight=0;
     float                 depthNear = 0;
+
+    const Tempest::Matrix4x4* extView = nullptr;
+    const Tempest::Matrix4x4* extProj = nullptr;
 
     bool                  dbg           = false;
     bool                  tgEnable      = true;

--- a/game/commandline.cpp
+++ b/game/commandline.cpp
@@ -145,6 +145,35 @@ CommandLine::CommandLine(int argc, const char** argv) {
     else if(arg=="--vr" || arg=="-vr") {
       vr = true;
       }
+    else if(arg.rfind("--vr-first-person",0)==0) {
+      vrFirstPerson = true;
+      auto p = arg.find('=');
+      if(p!=std::string_view::npos) {
+        auto val = arg.substr(p+1);
+        vrFirstPerson = (val!="0" && val!="off");
+      }
+      }
+    else if(arg.rfind("--vr-height-offset",0)==0) {
+      auto p = arg.find('=');
+      try {
+        if(p!=std::string_view::npos) {
+          vrHeight = std::stof(std::string(arg.substr(p+1)));
+        } else {
+          ++i;
+          if(i<argc)
+            vrHeight = std::stof(argv[i]);
+        }
+      } catch(...) {
+      }
+      }
+    else if(arg.rfind("--vr-allow-roll",0)==0) {
+      allowRoll = true;
+      auto p = arg.find('=');
+      if(p!=std::string_view::npos) {
+        auto val = arg.substr(p+1);
+        allowRoll = (val!="0" && val!="off");
+      }
+      }
     else {
       Log::i("unreacognized commandline option: \"", arg, "\"");
       }

--- a/game/commandline.h
+++ b/game/commandline.h
@@ -48,6 +48,9 @@ class CommandLine {
     bool                doForceG2NR()      const { return forceG2NR;    }
     bool                aaPreset()         const { return aaPresetId;   }
     bool                isVr()            const;
+    bool                isVrFirstPerson() const { return vrFirstPerson; }
+    float               vrHeightOffset()  const { return vrHeight;      }
+    bool                vrAllowRoll()     const { return allowRoll;     }
     std::string_view    defaultSave()      const { return saveDef;    }
 
     std::string         wrldDef;
@@ -81,5 +84,8 @@ class CommandLine {
     bool                forceG2NR    = false;
     uint32_t            aaPresetId = 0;
     bool                vr          = false;
+    bool                vrFirstPerson = true;
+    float               vrHeight      = 1.75f;
+    bool                allowRoll     = false;
   };
 

--- a/game/mainwindow.cpp
+++ b/game/mainwindow.cpp
@@ -1173,10 +1173,19 @@ void MainWindow::render(){
       if(xrBackend_->beginFrame()) {
         auto views = xrBackend_->views();
 
+        if(auto cam = Gothic::inst().camera()) {
+          if(CommandLine::inst().isVrFirstPerson())
+            cam->setExternalViewProj(&views[0].view,&views[0].proj);
+          else
+            cam->clearExternalViewProj();
+        }
+
         auto& sync = fence[cmdId];
         if(!sync.wait(0)) {
           std::this_thread::yield();
           xrBackend_->endFrame();
+          if(auto cam = Gothic::inst().camera())
+            cam->clearExternalViewProj();
           return;
         }
         Resources::resetRecycled(cmdId);
@@ -1205,6 +1214,8 @@ void MainWindow::render(){
         }
         device.submit(cmd,sync);
         xrBackend_->endFrame();
+        if(auto cam = Gothic::inst().camera())
+          cam->clearExternalViewProj();
         cmdId = (cmdId+1u)%Resources::MaxFramesInFlight;
         return;
       } else {

--- a/src/xr/OpenXRBackend.cpp
+++ b/src/xr/OpenXRBackend.cpp
@@ -5,6 +5,8 @@
 #include <Tempest/Device>
 #include <Tempest/Window>
 
+#include "../game/commandline.h"
+
 #include <cstring>
 #include <vector>
 #include <algorithm>
@@ -91,6 +93,57 @@ static Tempest::TextureFormat toTexFormat(VkFormat f) {
   return Tempest::TextureFormat::RGBA8;
 }
 
+static Tempest::Vec3 toVec3(const XrVector3f& v) {
+  return Tempest::Vec3{v.x,v.y,v.z};
+}
+
+static XrVector3f toXr(const Tempest::Vec3& v) {
+  return XrVector3f{v.x,v.y,v.z};
+}
+
+static Tempest::Vec3 rotate(const XrQuaternionf& q, const Tempest::Vec3& v) {
+  const float xx = q.x*q.x;
+  const float yy = q.y*q.y;
+  const float zz = q.z*q.z;
+  const float xy = q.x*q.y;
+  const float xz = q.x*q.z;
+  const float yz = q.y*q.z;
+  const float wx = q.w*q.x;
+  const float wy = q.w*q.y;
+  const float wz = q.w*q.z;
+  return Tempest::Vec3{
+      (1.f-2.f*yy-2.f*zz)*v.x + 2.f*(xy-wz)*v.y + 2.f*(xz+wy)*v.z,
+      2.f*(xy+wz)*v.x + (1.f-2.f*xx-2.f*zz)*v.y + 2.f*(yz-wx)*v.z,
+      2.f*(xz-wy)*v.x + 2.f*(yz+wx)*v.y + (1.f-2.f*xx-2.f*yy)*v.z};
+}
+
+static Tempest::Vec3 rotateInv(const XrQuaternionf& q, const Tempest::Vec3& v) {
+  return rotate(XrQuaternionf{-q.x,-q.y,-q.z,q.w}, v);
+}
+
+static XrQuaternionf removeRoll(const XrQuaternionf& q) {
+  const float ysqr = q.y*q.y;
+  float t0 = 2.f*(q.w*q.y + q.x*q.z);
+  float t1 = 1.f - 2.f*(ysqr + q.z*q.z);
+  float yaw = std::atan2(t0,t1);
+
+  float t2 = 2.f*(q.w*q.x - q.z*q.y);
+  t2 = std::clamp(t2,-1.f,1.f);
+  float pitch = std::asin(t2);
+
+  float cy = std::cos(yaw*0.5f);
+  float sy = std::sin(yaw*0.5f);
+  float cp = std::cos(pitch*0.5f);
+  float sp = std::sin(pitch*0.5f);
+
+  XrQuaternionf r{};
+  r.w = cy*cp;
+  r.x = cy*sp;
+  r.y = sy*cp;
+  r.z = -sy*sp;
+  return r;
+}
+
 }
 
 OpenXRBackend::OpenXRBackend() = default;
@@ -101,6 +154,11 @@ OpenXRBackend::~OpenXRBackend() {
 bool OpenXRBackend::initialize(Tempest::Device& dev, Tempest::Window& win) {
   (void)win;
   device = &dev;
+
+  auto& cmd = CommandLine::inst();
+  firstPerson  = cmd.isVrFirstPerson();
+  heightOffset = cmd.vrHeightOffset();
+  allowRoll    = cmd.vrAllowRoll();
 
   uint32_t extCount = 0;
   xrEnumerateInstanceExtensionProperties(nullptr, 0, &extCount, nullptr);
@@ -165,11 +223,23 @@ bool OpenXRBackend::initialize(Tempest::Device& dev, Tempest::Window& win) {
   XrReferenceSpaceCreateInfo rs{XR_TYPE_REFERENCE_SPACE_CREATE_INFO};
   rs.referenceSpaceType = XR_REFERENCE_SPACE_TYPE_LOCAL;
   rs.poseInReferenceSpace.orientation.w = 1.f;
-  if(xrCreateReferenceSpace(session,&rs,&space)!=XR_SUCCESS) {
+  if(xrCreateReferenceSpace(session,&rs,&refSpace)!=XR_SUCCESS) {
     Tempest::Log::e("xrCreateReferenceSpace failed");
     shutdown();
     return false;
   }
+
+  XrReferenceSpaceCreateInfo hs{XR_TYPE_REFERENCE_SPACE_CREATE_INFO};
+  hs.referenceSpaceType = XR_REFERENCE_SPACE_TYPE_VIEW;
+  hs.poseInReferenceSpace.orientation.w = 1.f;
+  if(xrCreateReferenceSpace(session,&hs,&headSpace)!=XR_SUCCESS) {
+    Tempest::Log::e("xrCreateReferenceSpace VIEW failed");
+    shutdown();
+    return false;
+  }
+
+  Tempest::Log::i("Reference space: LOCAL");
+  Tempest::Log::i("Head space: VIEW");
 
   Tempest::Log::i("View configuration: PRIMARY_STEREO");
 
@@ -225,9 +295,13 @@ void OpenXRBackend::shutdown() {
       xrDestroySwapchain(e.swapchain);
     e.swapchain = XR_NULL_HANDLE;
   }
-  if(space!=XR_NULL_HANDLE) {
-    xrDestroySpace(space);
-    space = XR_NULL_HANDLE;
+  if(headSpace!=XR_NULL_HANDLE) {
+    xrDestroySpace(headSpace);
+    headSpace = XR_NULL_HANDLE;
+  }
+  if(refSpace!=XR_NULL_HANDLE) {
+    xrDestroySpace(refSpace);
+    refSpace = XR_NULL_HANDLE;
   }
   if(session!=XR_NULL_HANDLE) {
     xrDestroySession(session);
@@ -250,10 +324,19 @@ bool OpenXRBackend::beginFrame() {
   if(xrBeginFrame(session,&bi)!=XR_SUCCESS)
     return false;
 
+  XrSpaceLocation headLoc{XR_TYPE_SPACE_LOCATION};
+  if(xrLocateSpace(headSpace, refSpace, frameState.predictedDisplayTime, &headLoc)==XR_SUCCESS) {
+    const XrSpaceLocationFlags req = XR_SPACE_LOCATION_POSITION_VALID_BIT | XR_SPACE_LOCATION_ORIENTATION_VALID_BIT;
+    if((headLoc.locationFlags & req)==req) {
+      headPose = headLoc.pose;
+      hasPose  = true;
+    }
+  }
+
   XrViewLocateInfo vi{XR_TYPE_VIEW_LOCATE_INFO};
   vi.viewConfigurationType = XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;
   vi.displayTime = frameState.predictedDisplayTime;
-  vi.space       = space;
+  vi.space       = refSpace;
 
   uint32_t viewCount = eyes.size();
   std::vector<XrView> xrViews(viewCount, {XR_TYPE_VIEW});
@@ -261,10 +344,29 @@ bool OpenXRBackend::beginFrame() {
   if(xrLocateViews(session,&vi,&vs,viewCount,&viewCount,xrViews.data())!=XR_SUCCESS)
     return false;
 
+  XrQuaternionf headQ = headPose.orientation;
+  if(hasPose && !allowRoll)
+    headQ = removeRoll(headPose.orientation);
+  Tempest::Vec3 headPos = toVec3(headPose.position);
+  headPos.y += heightOffset;
+
   for(uint32_t i=0;i<viewCount && i<eyes.size();++i) {
-    eyes[i].view    = xrViews[i];
-    eyes[i].projMat = toTempest(xrMatProjection(xrViews[i].fov, 0.1f, 1000.f));
-    eyes[i].viewMat = toTempest(xrMatView(xrViews[i].pose));
+    XrPosef pose = xrViews[i].pose;
+    if(hasPose) {
+      Tempest::Vec3 eyePos   = toVec3(xrViews[i].pose.position);
+      Tempest::Vec3 offset   = eyePos - toVec3(headPose.position);
+      Tempest::Vec3 offLocal = rotateInv(headPose.orientation, offset);
+      Tempest::Vec3 pos      = rotate(headQ, offLocal) + headPos;
+      pose.orientation = headQ;
+      pose.position    = toXr(pos);
+    } else {
+      pose.position.y += heightOffset;
+    }
+
+    eyes[i].view.pose = pose;
+    eyes[i].view.fov  = xrViews[i].fov;
+    eyes[i].projMat   = toTempest(xrMatProjection(xrViews[i].fov, 0.1f, 1000.f));
+    eyes[i].viewMat   = toTempest(xrMatView(pose));
 
     XrSwapchainImageAcquireInfo ai{XR_TYPE_SWAPCHAIN_IMAGE_ACQUIRE_INFO};
     xrAcquireSwapchainImage(eyes[i].swapchain,&ai,&eyes[i].acquired);
@@ -274,6 +376,11 @@ bool OpenXRBackend::beginFrame() {
 
     auto& img = eyes[i].images[eyes[i].acquired];
     eyes[i].color = Tempest::Attachment(*device, img.image, eyes[i].width, eyes[i].height, toTexFormat(eyes[i].format));
+  }
+
+  if(firstPerson && !loggedFp) {
+    Tempest::Log::d("VR first-person camera: height ", heightOffset, " allow roll ", allowRoll);
+    loggedFp = true;
   }
 
   return true;
@@ -299,7 +406,7 @@ void OpenXRBackend::endFrame() {
   }
 
   XrCompositionLayerProjection layer{XR_TYPE_COMPOSITION_LAYER_PROJECTION};
-  layer.space     = space;
+  layer.space     = refSpace;
   layer.viewCount = (uint32_t)pv.size();
   layer.views     = pv.data();
 

--- a/src/xr/OpenXRBackend.h
+++ b/src/xr/OpenXRBackend.h
@@ -39,10 +39,17 @@ private:
 
   std::array<Eye,2> eyes;
 
-  XrInstance    instance = XR_NULL_HANDLE;
-  XrSystemId    systemId = XR_NULL_SYSTEM_ID;
-  XrSession     session  = XR_NULL_HANDLE;
-  XrSpace       space    = XR_NULL_HANDLE;
+  XrInstance    instance   = XR_NULL_HANDLE;
+  XrSystemId    systemId   = XR_NULL_SYSTEM_ID;
+  XrSession     session    = XR_NULL_HANDLE;
+  XrSpace       refSpace   = XR_NULL_HANDLE;
+  XrSpace       headSpace  = XR_NULL_HANDLE;
+  XrPosef       headPose{{0,0,0,1},{0,0,0}};
+  bool          hasPose    = false;
+  bool          firstPerson = true;
+  float         heightOffset = 1.75f;
+  bool          allowRoll    = false;
+  bool          loggedFp     = false;
   XrFrameState  frameState{XR_TYPE_FRAME_STATE};
 };
 #endif


### PR DESCRIPTION
## Summary
- drive in-game camera from OpenXR head pose with height offset and optional roll clamp
- add command line options for VR first-person, height offset and roll roll
- wire camera overrides in VR render path and document usage

## Testing
- `cmake -S . -B build -DOPENXR_ENABLED=ON` *(fails: OpenXR SDK not found)*
- `cmake -S . -B build -DOPENXR_ENABLED=OFF` *(fails: glslangValidator required)*

------
https://chatgpt.com/codex/tasks/task_e_68c5bb57f658833186935f1e6b8f3e2a