### PR TITLE
Add keyboard snap-turn for VR sessions

### DIFF
--- a/README_VR.md
+++ b/README_VR.md
@@ -6,5 +6,6 @@ Run the game with `--vr` to enable the OpenXR backend.
 * `--vr-first-person=on|off` – toggle first person camera (default `on`).
 * `--vr-height-offset=<m>` – vertical eye offset in meters (default `1.75`).
 * `--vr-allow-roll=on|off` – allow roll from the headset (default `off`).
+* `--vr-snap-deg=<deg>` – snap turn angle per key press (default `30`).
 
 Keyboard, mouse and gamepad remain for movement and turning.

--- a/game/commandline.cpp
+++ b/game/commandline.cpp
@@ -173,7 +173,22 @@ CommandLine::CommandLine(int argc, const char** argv) {
         auto val = arg.substr(p+1);
         allowRoll = (val!="0" && val!="off");
       }
+    }
+    else if(arg.rfind("--vr-snap-deg",0)==0) {
+      int snap = 30;
+      auto p = arg.find('=');
+      try {
+        if(p!=std::string_view::npos) {
+          snap = std::stoi(std::string(arg.substr(p+1)));
+        } else {
+          ++i;
+          if(i<argc)
+            snap = std::stoi(argv[i]);
+        }
+      } catch(...) {
       }
+      vrSnap = std::clamp(snap,5,90);
+    }
     else {
       Log::i("unreacognized commandline option: \"", arg, "\"");
       }

--- a/game/commandline.h
+++ b/game/commandline.h
@@ -51,6 +51,7 @@ class CommandLine {
     bool                isVrFirstPerson() const { return vrFirstPerson; }
     float               vrHeightOffset()  const { return vrHeight;      }
     bool                vrAllowRoll()     const { return allowRoll;     }
+    int                 vrSnapAngle()     const { return vrSnap;        }
     std::string_view    defaultSave()      const { return saveDef;    }
 
     std::string         wrldDef;
@@ -87,5 +88,6 @@ class CommandLine {
     bool                vrFirstPerson = true;
     float               vrHeight      = 1.75f;
     bool                allowRoll     = false;
+    int                 vrSnap        = 30;
   };
 

--- a/game/mainwindow.cpp
+++ b/game/mainwindow.cpp
@@ -8,6 +8,8 @@
 #include <Tempest/Layout>
 #include <Tempest/Application>
 #include <Tempest/Log>
+#include <Tempest/Matrix4x4>
+#include <cmath>
 
 #include "ui/dialogmenu.h"
 #include "ui/menuroot.h"
@@ -439,6 +441,20 @@ void MainWindow::keyDownEvent(KeyEvent &event) {
     }
   uiKeyUp=nullptr;
 
+  if(xrBackend_!=nullptr) {
+    float step = CommandLine::inst().vrSnapAngle()*float(M_PI/180.f);
+    if(event.key==Event::K_Q) {
+      vrSnapYaw -= step;
+      event.accept();
+      return;
+    }
+    if(event.key==Event::K_E) {
+      vrSnapYaw += step;
+      event.accept();
+      return;
+    }
+  }
+
   auto act = keycodec.tr(event);
   auto mapping = keycodec.mapping(event);
   player.onKeyPressed(act,event.key,mapping);
@@ -449,7 +465,7 @@ void MainWindow::keyDownEvent(KeyEvent &event) {
     pm.save("dbg.png");
     }
   event.accept();
-  }
+}
 
 void MainWindow::keyRepeatEvent(KeyEvent& event) {
   if(uiKeyUp==&video){
@@ -478,7 +494,18 @@ void MainWindow::keyRepeatEvent(KeyEvent& event) {
     if(event.isAccepted())
       return;
     }
+  if(xrBackend_!=nullptr) {
+    float step = CommandLine::inst().vrSnapAngle()*float(M_PI/180.f);
+    if(event.key==Event::K_Q) {
+      vrSnapYaw -= step;
+      event.accept();
+    }
+    if(event.key==Event::K_E) {
+      vrSnapYaw += step;
+      event.accept();
+    }
   }
+}
 
 void MainWindow::keyUpEvent(KeyEvent &event) {
   if(uiKeyUp==&video){
@@ -1172,6 +1199,16 @@ void MainWindow::render(){
     if(xrBackend_!=nullptr) {
       if(xrBackend_->beginFrame()) {
         auto views = xrBackend_->views();
+        if(vrSnapYaw!=0.f) {
+          Matrix4x4 rot;
+          rot.identity();
+          rot.rotateOY(vrSnapYaw);
+          for(auto& eye:views) {
+            Matrix4x4 m = rot;
+            m.mul(eye.view);
+            eye.view = m;
+          }
+        }
 
         if(auto cam = Gothic::inst().camera()) {
           if(CommandLine::inst().isVrFirstPerson())
@@ -1222,6 +1259,7 @@ void MainWindow::render(){
         xrBackend_->shutdown();
         delete xrBackend_;
         xrBackend_ = nullptr;
+        vrSnapYaw = 0.f;
       }
     }
 

--- a/game/mainwindow.h
+++ b/game/mainwindow.h
@@ -180,4 +180,5 @@ class MainWindow : public Tempest::Window {
     Fps        fps;
     Benchmark  benchmark;
     uint64_t   maxFpsInv = 0;
+    float      vrSnapYaw = 0.f;
   };


### PR DESCRIPTION
## Summary
- add optional `--vr-snap-deg` flag to control snap turn angle
- map Q/E keys to accumulate snap yaw when VR is enabled
- apply and reset yaw offset in XR render path

## Testing
- `cmake -S . -B build` (fails: missing Vulkan headers during build)


------
https://chatgpt.com/codex/tasks/task_e_68c5c161b9048331980f54113a628e1a