### PR TITLE
Add basic VR HUD quad layer and options

### DIFF
--- a/README_VR.md
+++ b/README_VR.md
@@ -32,3 +32,15 @@ Additional options:
 - `--vr-snap-cooldown-ms=<int>` – cooldown between snap turns (default `250`)
 - `--vr-move-speed-scale=<float>` – movement speed multiplier (default `1.0`)
 - `--vr-vignette-strength=<0..1>` – comfort vignette strength (default `0`)
+
+## HUD/UI in VR
+
+The 2D interface can be rendered onto a floating quad in front of the player.
+Available options:
+
+- `--vr-hud-distance=<meters>` – distance from the head to the HUD plane (default `1.4`)
+- `--vr-hud-width=<meters>` – physical width of the HUD quad (default `1.0`)
+- `--vr-hud-scale=<0.5..2.0>` – additional HUD scale factor (default `1.0`)
+- `--vr-hud-pitch-deg=<deg>` – pitch offset of the quad in degrees (default `-10`)
+- `--vr-hud-follow=on|off` – make the HUD follow the head (default `on`)
+- `--vr-hud-res-scale=<float>` – resolution scale for the offscreen HUD texture (default `1.0`)

--- a/game/commandline.cpp
+++ b/game/commandline.cpp
@@ -253,6 +253,62 @@ CommandLine::CommandLine(int argc, const char** argv) {
       } catch(...) {}
       vrVignette = std::clamp(vrVignette,0.f,1.f);
     }
+    else if(arg.rfind("--vr-hud-distance",0)==0) {
+      auto p = arg.find('=');
+      try {
+        if(p!=std::string_view::npos)
+          vrHudDist = std::stof(std::string(arg.substr(p+1)));
+        else if(i+1<argc)
+          vrHudDist = std::stof(argv[++i]);
+      } catch(...) {}
+    }
+    else if(arg.rfind("--vr-hud-width",0)==0) {
+      auto p = arg.find('=');
+      try {
+        if(p!=std::string_view::npos)
+          vrHudWidth = std::stof(std::string(arg.substr(p+1)));
+        else if(i+1<argc)
+          vrHudWidth = std::stof(argv[++i]);
+      } catch(...) {}
+    }
+    else if(arg.rfind("--vr-hud-scale",0)==0) {
+      auto p = arg.find('=');
+      try {
+        if(p!=std::string_view::npos)
+          vrHudScale = std::stof(std::string(arg.substr(p+1)));
+        else if(i+1<argc)
+          vrHudScale = std::stof(argv[++i]);
+      } catch(...) {}
+    }
+    else if(arg.rfind("--vr-hud-pitch-deg",0)==0) {
+      auto p = arg.find('=');
+      try {
+        if(p!=std::string_view::npos)
+          vrHudPitch = std::stof(std::string(arg.substr(p+1)));
+        else if(i+1<argc)
+          vrHudPitch = std::stof(argv[++i]);
+      } catch(...) {}
+    }
+    else if(arg.rfind("--vr-hud-follow",0)==0) {
+      auto p = arg.find('=');
+      std::string v;
+      if(p!=std::string_view::npos)
+        v = std::string(arg.substr(p+1));
+      else if(i+1<argc)
+        v = argv[++i];
+      if(!v.empty()) {
+        vrHudFollow = !(v=="off" || v=="0" || v=="false");
+      }
+    }
+    else if(arg.rfind("--vr-hud-res-scale",0)==0) {
+      auto p = arg.find('=');
+      try {
+        if(p!=std::string_view::npos)
+          vrHudRes = std::stof(std::string(arg.substr(p+1)));
+        else if(i+1<argc)
+          vrHudRes = std::stof(argv[++i]);
+      } catch(...) {}
+    }
     else {
       Log::i("unreacognized commandline option: \"", arg, "\"");
     }

--- a/game/commandline.h
+++ b/game/commandline.h
@@ -59,6 +59,13 @@ class CommandLine {
     int                 vrSnapCooldown()  const { return vrSnapCooldown;}
     float               vrMoveSpeedScale()const { return vrMoveScale;   }
     float               vrVignetteStrength() const { return vrVignette; }
+
+    float               vrHudDistance()   const { return vrHudDist;    }
+    float               vrHudWidth()      const { return vrHudWidth;   }
+    float               vrHudScale()      const { return vrHudScale;   }
+    float               vrHudPitchDeg()   const { return vrHudPitch;   }
+    bool                vrHudFollow()     const { return vrHudFollow;  }
+    float               vrHudResScale()   const { return vrHudRes;     }
     std::string_view    defaultSave()      const { return saveDef;    }
 
     std::string         wrldDef;
@@ -103,5 +110,11 @@ class CommandLine {
     int                 vrSnapCooldown= 250;
     float               vrMoveScale   = 1.f;
     float               vrVignette    = 0.f;
+    float               vrHudDist     = 1.4f;
+    float               vrHudWidth    = 1.0f;
+    float               vrHudScale    = 1.0f;
+    float               vrHudPitch    = -10.f;
+    bool                vrHudFollow   = true;
+    float               vrHudRes      = 1.0f;
   };
 

--- a/game/mainwindow.cpp
+++ b/game/mainwindow.cpp
@@ -9,6 +9,8 @@
 #include <Tempest/Application>
 #include <Tempest/Log>
 #include <Tempest/Matrix4x4>
+#include <Tempest/TextureFormat>
+#include <Tempest/Vec4>
 #include <cmath>
 #include <algorithm>
 #include <Tempest/Vec3>
@@ -1291,14 +1293,39 @@ void MainWindow::render(){
         uiMesh [cmdId].update(device,uiLayer);
         numMesh[cmdId].update(device,numOverlay);
 
+        int hudW = int(1920 * CommandLine::inst().vrHudResScale());
+        int hudH = int(1080 * CommandLine::inst().vrHudResScale());
+        if(vrHud.isEmpty() || vrHud.w()!=uint32_t(hudW) || vrHud.h()!=uint32_t(hudH)) {
+          vrHud = device.attachment(Tempest::TextureFormat::RGBA8, hudW, hudH);
+          vrHudDepth = device.zbuffer(Tempest::TextureFormat::Depth16, hudW, hudH);
+        }
+
         CommandBuffer& cmd = commands[cmdId];
         {
           auto enc = cmd.startEncoding(device);
           for(auto& eye:views) {
-            renderer.draw(eye.color, enc, cmdId, uiMesh[cmdId], numMesh[cmdId], inventory, video, eye.view, eye.proj);
+            renderer.draw(eye.color, enc, cmdId);
+          }
+          enc.setFramebuffer({{vrHud, Tempest::Discard, Tempest::Preserve}});
+          enc.setDebugMarker("VR-HUD");
+          uiMesh[cmdId].draw(enc);
+          if(inventory.isOpen()!=InventoryMenu::State::Closed) {
+            enc.setFramebuffer({{vrHud, Tempest::Preserve, Tempest::Preserve}},{vrHudDepth,1.f,Tempest::Preserve});
+            inventory.draw(enc);
+            enc.setFramebuffer({{vrHud, Tempest::Preserve, Tempest::Preserve}});
+            numMesh[cmdId].draw(enc);
           }
         }
         device.submit(cmd,sync);
+
+        IXRBackend::XRQuadLayerDesc hud{};
+        hud.image = vrHud;
+        hud.width = hudW;
+        hud.height= hudH;
+        hud.metersWidth = CommandLine::inst().vrHudWidth()*CommandLine::inst().vrHudScale();
+        hud.position = Tempest::Vec3{0.f,0.f,-CommandLine::inst().vrHudDistance()};
+        hud.orientation = Tempest::Vec4{0.f,0.f,0.f,1.f};
+        xrBackend_->setUiQuad(&hud);
         xrBackend_->endFrame();
         if(auto cam = Gothic::inst().camera())
           cam->clearExternalViewProj();

--- a/game/mainwindow.h
+++ b/game/mainwindow.h
@@ -184,4 +184,7 @@ class MainWindow : public Tempest::Window {
     uint64_t   vrSnapTime = 0;
     bool       vrTelePrev = false;
     bool       vrAttackPrev = false;
+
+    Tempest::Attachment vrHud;
+    Tempest::ZBuffer    vrHudDepth;
   };

--- a/include/xr/IXRBackend.h
+++ b/include/xr/IXRBackend.h
@@ -4,12 +4,22 @@
 #include <Tempest/Attachment>
 #include <Tempest/Vec2>
 #include <Tempest/Vec3>
+#include <Tempest/Vec4>
 namespace Tempest { class Device; class Window; }
 struct EyeInfo {
   Tempest::Matrix4x4 view;
   Tempest::Matrix4x4 proj;
   Tempest::Attachment color; // wrapped external VkImage for this frame
   Tempest::Attachment depth; // optional depth buffer
+};
+
+struct XRQuadLayerDesc {
+  Tempest::Attachment image;
+  int                 width = 0;
+  int                 height = 0;
+  float               metersWidth = 1.f;
+  Tempest::Vec3       position{};
+  Tempest::Vec4       orientation{}; // quaternion x,y,z,w
 };
 class IXRBackend {
 public:
@@ -19,6 +29,7 @@ public:
   virtual bool beginFrame() = 0;
   virtual void endFrame() = 0;
   virtual std::array<EyeInfo,2> views() const = 0; // returns default/empty at P1
+  virtual void setUiQuad(const XRQuadLayerDesc* desc) = 0;
 
   struct XRInputState {
     struct Pose {

--- a/src/xr/OpenXRBackend.cpp
+++ b/src/xr/OpenXRBackend.cpp
@@ -504,16 +504,29 @@ void OpenXRBackend::endFrame() {
   layer.viewCount = (uint32_t)pv.size();
   layer.views     = pv.data();
 
-  const XrCompositionLayerBaseHeader* layers[] = {
-    reinterpret_cast<const XrCompositionLayerBaseHeader*>(&layer)
-  };
+  const XrCompositionLayerBaseHeader* layers[2];
+  uint32_t layerCount = 0;
+  layers[layerCount++] = reinterpret_cast<const XrCompositionLayerBaseHeader*>(&layer);
+
+  XrCompositionLayerQuad quadLayer{XR_TYPE_COMPOSITION_LAYER_QUAD};
+  if(uiQuad) {
+    quadLayer.space = refSpace;
+    quadLayer.pose.orientation = {uiQuad->orientation.x, uiQuad->orientation.y, uiQuad->orientation.z, uiQuad->orientation.w};
+    quadLayer.pose.position = {uiQuad->position.x, uiQuad->position.y, uiQuad->position.z};
+    quadLayer.size = {uiQuad->metersWidth, uiQuad->metersWidth * float(uiQuad->height)/float(uiQuad->width)};
+    quadLayer.subImage.swapchain = XR_NULL_HANDLE;
+    quadLayer.subImage.imageRect.offset = {0,0};
+    quadLayer.subImage.imageRect.extent = {uiQuad->width, uiQuad->height};
+    layers[layerCount++] = reinterpret_cast<const XrCompositionLayerBaseHeader*>(&quadLayer);
+  }
 
   XrFrameEndInfo ei{XR_TYPE_FRAME_END_INFO};
   ei.displayTime = frameState.predictedDisplayTime;
   ei.environmentBlendMode = XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
-  ei.layerCount = 1;
+  ei.layerCount = layerCount;
   ei.layers = layers;
   xrEndFrame(session,&ei);
+  uiQuad = nullptr;
 }
 
 std::array<EyeInfo,2> OpenXRBackend::views() const {

--- a/src/xr/OpenXRBackend.h
+++ b/src/xr/OpenXRBackend.h
@@ -20,6 +20,7 @@ public:
   void pollInput() override;
   const XRInputState& inputState() const override { return input; }
   void hapticPulse(float amplitude, float seconds) override;
+  void setUiQuad(const XRQuadLayerDesc* desc) override { uiQuad = desc; }
 
 private:
   struct Eye {
@@ -68,5 +69,6 @@ private:
   XrSpace       aimSpace    = XR_NULL_HANDLE;
   XrPath        handPath[2] = {XR_NULL_PATH,XR_NULL_PATH};
   XRInputState  input{};
+  const XRQuadLayerDesc* uiQuad = nullptr;
 };
 #endif


### PR DESCRIPTION
## Summary
- add command line controls for VR HUD distance, size, scale and behavior
- support optional quad layer submission in OpenXR backend
- render HUD to offscreen texture in VR and submit it as quad layer
- document VR HUD/UI options

## Testing
- `cmake ..` *(fails: missing OpenGL library but build files generated)*
- `cmake --build .` *(interrupted after beginning lengthy compile)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f278aeb0833194d2bba328bd2eac