### PR TITLE
feat: add VR HUD export and laser pointer

### DIFF
--- a/README_VR.md
+++ b/README_VR.md
@@ -44,3 +44,7 @@ Available options:
 - `--vr-hud-pitch-deg=<deg>` – pitch offset of the quad in degrees (default `-10`)
 - `--vr-hud-follow=on|off` – make the HUD follow the head (default `on`)
 - `--vr-hud-res-scale=<float>` – resolution scale for the offscreen HUD texture (default `1.0`)
+
+### Laser pointer & Follow
+
+Aim with the right-hand controller; the trigger (interact) maps to a mouse click on the HUD quad. The quad position can be tuned via `--vr-hud-distance`, `--vr-hud-width`, `--vr-hud-scale`, `--vr-hud-pitch-deg`, `--vr-hud-follow` and `--vr-hud-res-scale`. When follow is enabled, the quad smoothly tethers to head movement with gentle smoothing.

--- a/game/mainwindow.cpp
+++ b/game/mainwindow.cpp
@@ -33,6 +33,34 @@
 #include "gothic.h"
 
 using namespace Tempest;
+#ifdef OPENXR_ENABLED
+#include <gapi/vulkan/vtexture.h>
+#include <cmath>
+namespace {
+static Tempest::Vec3 rotate(const Tempest::Vec4& q, const Tempest::Vec3& v) {
+  const float x = q.x, y = q.y, z = q.z, w = q.w;
+  return Tempest::Vec3{
+      (1.f-2.f*y*y-2.f*z*z)*v.x + 2.f*(x*y-w*z)*v.y + 2.f*(x*z+w*y)*v.z,
+      2.f*(x*y+w*z)*v.x + (1.f-2.f*x*x-2.f*z*z)*v.y + 2.f*(y*z-w*x)*v.z,
+      2.f*(x*z-w*y)*v.x + 2.f*(y*z+w*x)*v.y + (1.f-2.f*x*x-2.f*y*y)*v.z};
+}
+static Tempest::Vec3 rotateInv(const Tempest::Vec4& q, const Tempest::Vec3& v) {
+  return rotate(Tempest::Vec4{-q.x,-q.y,-q.z,q.w}, v);
+}
+static float quatYaw(const Tempest::Vec4& q) {
+  float siny_cosp = 2.f*(q.w*q.y + q.x*q.z);
+  float cosy_cosp = 1.f - 2.f*(q.y*q.y + q.z*q.z);
+  return std::atan2(siny_cosp, cosy_cosp);
+}
+static Tempest::Vec4 quatFromYawPitch(float yaw, float pitch) {
+  float cy = std::cos(yaw*0.5f);
+  float sy = std::sin(yaw*0.5f);
+  float cp = std::cos(pitch*0.5f);
+  float sp = std::sin(pitch*0.5f);
+  return Tempest::Vec4{sp*cy, sy*cp, -sy*sp, cy*cp};
+}
+}
+#endif
 
 MainWindow::MainWindow(Device& device, IXRBackend* xr)
   : Window(Maximized),device(device),xrBackend_(xr),swapchain(device,hwnd()),
@@ -1318,15 +1346,44 @@ void MainWindow::render(){
         }
         device.submit(cmd,sync);
 
-        IXRBackend::XRQuadLayerDesc hud{};
-        hud.image = vrHud;
-        hud.width = hudW;
-        hud.height= hudH;
-        hud.metersWidth = CommandLine::inst().vrHudWidth()*CommandLine::inst().vrHudScale();
-        hud.position = Tempest::Vec3{0.f,0.f,-CommandLine::inst().vrHudDistance()};
-        hud.orientation = Tempest::Vec4{0.f,0.f,0.f,1.f};
-        xrBackend_->setUiQuad(&hud);
-        xrBackend_->endFrame();
+        HudImageInfo imgInfo{};
+        if(getVrHudImage(imgInfo)) {
+          float hudScale = CommandLine::inst().vrHudScale();
+          float hudMeters = CommandLine::inst().vrHudWidth()*hudScale;
+          Tempest::Vec4 headQ = xrBackend_->headOrientation();
+          Tempest::Vec3 headPos = xrBackend_->headPosition();
+          float targetYaw = quatYaw(headQ);
+          float dist = CommandLine::inst().vrHudDistance();
+          float pitch = CommandLine::inst().vrHudPitchDeg()*float(M_PI)/180.f;
+          Tempest::Vec3 forward = rotate(quatFromYawPitch(targetYaw,0.f), Tempest::Vec3{0,0,-1});
+          Tempest::Vec3 targetPos = headPos + forward*dist;
+          if(!hudInitialized) {
+            hudPos = targetPos;
+            hudYaw = targetYaw;
+            hudInitialized = true;
+          } else if(CommandLine::inst().vrHudFollow()) {
+            hudPos += (targetPos-hudPos)*0.15f;
+            float dy = targetYaw - hudYaw;
+            if(dy>float(M_PI)) dy-=float(2*M_PI);
+            if(dy<-float(M_PI)) dy+=float(2*M_PI);
+            hudYaw += dy*0.15f;
+          }
+          Tempest::Vec4 hudQ = quatFromYawPitch(hudYaw, pitch);
+          IXRBackend::XRQuadLayerDesc hud{};
+          hud.image = imgInfo.image;
+          hud.format = imgInfo.format;
+          hud.layout = imgInfo.layout;
+          hud.width  = imgInfo.w;
+          hud.height = imgInfo.h;
+          hud.metersWidth = hudMeters;
+          hud.position = hudPos;
+          hud.orientation = hudQ;
+          handleVrPointer(hud);
+          xrBackend_->setUiQuad(&hud);
+          xrBackend_->endFrame();
+        } else {
+          xrBackend_->endFrame();
+        }
         if(auto cam = Gothic::inst().camera())
           cam->clearExternalViewProj();
         cmdId = (cmdId+1u)%Resources::MaxFramesInFlight;
@@ -1429,3 +1486,66 @@ void MainWindow::Benchmark::clear() {
   numFrames = 0;
   fpsSum = 0;
   }
+
+#ifdef OPENXR_ENABLED
+bool MainWindow::getVrHudImage(HudImageInfo& out) const {
+  if(vrHud.isEmpty())
+    return false;
+  auto& tex = textureCast<const Texture2d&>(vrHud);
+  auto* vkTex = reinterpret_cast<Tempest::Detail::VTexture*>(tex.impl.handler);
+  out.image  = vkTex->impl;
+  out.w      = tex.w();
+  out.h      = tex.h();
+  out.format = vkTex->format;
+  out.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+  return true;
+}
+#endif
+
+#ifdef OPENXR_ENABLED
+void MainWindow::handleVrPointer(const IXRBackend::XRQuadLayerDesc& hud) {
+  const auto& st = xrBackend_->inputState();
+  if(!st.aim.valid) {
+    if(vrPointerPressed && !st.interact) {
+      Tempest::MouseEvent mu(0,0,Tempest::MouseEvent::ButtonLeft);
+      mouseUpEvent(mu);
+      vrPointerPressed=false;
+    }
+    return;
+  }
+  Tempest::Vec3 normal = rotate(hud.orientation, Tempest::Vec3{0.f,0.f,1.f});
+  float denom = Tempest::Vec3::dotProduct(st.aim.dir, normal);
+  if(std::fabs(denom) < 1e-6f)
+    return;
+  float t = Tempest::Vec3::dotProduct(hud.position - st.aim.pos, normal)/denom;
+  if(t<=0.f)
+    return;
+  Tempest::Vec3 hit = st.aim.pos + st.aim.dir*t;
+  Tempest::Vec3 local = rotateInv(hud.orientation, hit - hud.position);
+  float widthM  = hud.metersWidth;
+  float heightM = hud.metersWidth * float(hud.height)/float(hud.width);
+  float u = local.x/widthM + 0.5f;
+  float v = -local.y/heightM + 0.5f;
+  if(u<0.f || u>1.f || v<0.f || v>1.f) {
+    if(vrPointerPressed) {
+      Tempest::MouseEvent mu(0,0,Tempest::MouseEvent::ButtonLeft);
+      mouseUpEvent(mu);
+      vrPointerPressed=false;
+    }
+    return;
+  }
+  int px = int(u*float(hud.width));
+  int py = int(v*float(hud.height));
+  Tempest::MouseEvent mv(px,py,Tempest::MouseEvent::ButtonNone);
+  mouseMoveEvent(mv);
+  if(st.interact && !vrPointerPressed) {
+    Tempest::MouseEvent md(px,py,Tempest::MouseEvent::ButtonLeft);
+    mouseDownEvent(md);
+    vrPointerPressed=true;
+  } else if(!st.interact && vrPointerPressed) {
+    Tempest::MouseEvent mu(px,py,Tempest::MouseEvent::ButtonLeft);
+    mouseUpEvent(mu);
+    vrPointerPressed=false;
+  }
+}
+#endif

--- a/game/mainwindow.h
+++ b/game/mainwindow.h
@@ -43,12 +43,26 @@ class MenuRoot;
 class GameSession;
 class Interactive;
 
+#ifdef OPENXR_ENABLED
+struct HudImageInfo {
+  VkImage       image = VK_NULL_HANDLE;
+  int           w = 0;
+  int           h = 0;
+  VkImageLayout layout = VK_IMAGE_LAYOUT_UNDEFINED;
+  VkFormat      format = VK_FORMAT_UNDEFINED;
+};
+#endif
+
 class MainWindow : public Tempest::Window {
   public:
     explicit MainWindow(Tempest::Device& device, IXRBackend* xr);
     ~MainWindow() override;
 
     float uiScale() const;
+
+#ifdef OPENXR_ENABLED
+    bool getVrHudImage(HudImageInfo& out) const;
+#endif
 
   private:
     void paintEvent     (Tempest::PaintEvent& event) override;
@@ -101,6 +115,9 @@ class MainWindow : public Tempest::Window {
     void     updateAnimation(uint64_t dt);
     void     tickCamera(uint64_t dt);
     void     isDialogClosed(bool& ret);
+#ifdef OPENXR_ENABLED
+    void     handleVrPointer(const IXRBackend::XRQuadLayerDesc& hud);
+#endif
 
     template<Tempest::KeyEvent::KeyType k>
     void     onMarvinKey();
@@ -187,4 +204,11 @@ class MainWindow : public Tempest::Window {
 
     Tempest::Attachment vrHud;
     Tempest::ZBuffer    vrHudDepth;
+
+#ifdef OPENXR_ENABLED
+    Tempest::Vec3        hudPos{};
+    float                hudYaw = 0.f;
+    bool                 hudInitialized = false;
+    bool                 vrPointerPressed = false;
+#endif
   };

--- a/include/xr/IXRBackend.h
+++ b/include/xr/IXRBackend.h
@@ -5,6 +5,7 @@
 #include <Tempest/Vec2>
 #include <Tempest/Vec3>
 #include <Tempest/Vec4>
+#include <vulkan/vulkan.h>
 namespace Tempest { class Device; class Window; }
 struct EyeInfo {
   Tempest::Matrix4x4 view;
@@ -14,8 +15,10 @@ struct EyeInfo {
 };
 
 struct XRQuadLayerDesc {
-  Tempest::Attachment image;
-  int                 width = 0;
+  VkImage             image = VK_NULL_HANDLE;
+  VkFormat            format = VK_FORMAT_UNDEFINED;
+  VkImageLayout       layout = VK_IMAGE_LAYOUT_UNDEFINED;
+  int                 width  = 0;
   int                 height = 0;
   float               metersWidth = 1.f;
   Tempest::Vec3       position{};
@@ -30,6 +33,9 @@ public:
   virtual void endFrame() = 0;
   virtual std::array<EyeInfo,2> views() const = 0; // returns default/empty at P1
   virtual void setUiQuad(const XRQuadLayerDesc* desc) = 0;
+
+  virtual Tempest::Vec3 headPosition() const = 0;
+  virtual Tempest::Vec4 headOrientation() const = 0;
 
   struct XRInputState {
     struct Pose {

--- a/src/xr/OpenXRBackend.cpp
+++ b/src/xr/OpenXRBackend.cpp
@@ -4,6 +4,8 @@
 #include <Tempest/Log>
 #include <Tempest/Device>
 #include <Tempest/Window>
+#include <gapi/vulkan/vdevice.h>
+#include <gapi/vulkan/vtexture.h>
 
 #include "../game/commandline.h"
 
@@ -510,11 +512,58 @@ void OpenXRBackend::endFrame() {
 
   XrCompositionLayerQuad quadLayer{XR_TYPE_COMPOSITION_LAYER_QUAD};
   if(uiQuad) {
+    if(uiLayer.swapchain==XR_NULL_HANDLE || uiLayer.width!=uint32_t(uiQuad->width) ||
+       uiLayer.height!=uint32_t(uiQuad->height) || uiLayer.format!=uiQuad->format) {
+      if(uiLayer.swapchain!=XR_NULL_HANDLE)
+        xrDestroySwapchain(uiLayer.swapchain);
+      XrSwapchainCreateInfo sci{XR_TYPE_SWAPCHAIN_CREATE_INFO};
+      sci.usageFlags = XR_SWAPCHAIN_USAGE_SAMPLED_BIT | XR_SWAPCHAIN_USAGE_TRANSFER_DST_BIT;
+      sci.format     = uiQuad->format;
+      sci.sampleCount= 1;
+      sci.width      = uint32_t(uiQuad->width);
+      sci.height     = uint32_t(uiQuad->height);
+      sci.arraySize  = 1;
+      sci.mipCount   = 1;
+      xrCreateSwapchain(session,&sci,&uiLayer.swapchain);
+      uint32_t imgCount=0;
+      xrEnumerateSwapchainImages(uiLayer.swapchain,0,&imgCount,nullptr);
+      uiLayer.images.resize(imgCount,{XR_TYPE_SWAPCHAIN_IMAGE_VULKAN2_KHR});
+      xrEnumerateSwapchainImages(uiLayer.swapchain,imgCount,&imgCount,
+                                 reinterpret_cast<XrSwapchainImageBaseHeader*>(uiLayer.images.data()));
+      uiLayer.width  = sci.width;
+      uiLayer.height = sci.height;
+      uiLayer.format = uiQuad->format;
+    }
+
+    XrSwapchainImageAcquireInfo ai{XR_TYPE_SWAPCHAIN_IMAGE_ACQUIRE_INFO};
+    xrAcquireSwapchainImage(uiLayer.swapchain,&ai,&uiLayer.acquired);
+    XrSwapchainImageWaitInfo wi2{XR_TYPE_SWAPCHAIN_IMAGE_WAIT_INFO};
+    wi2.timeout = XR_INFINITE_DURATION;
+    xrWaitSwapchainImage(uiLayer.swapchain,&wi2);
+
+    Tempest::Attachment src(*device, uiQuad->image, uiQuad->width, uiQuad->height, toTexFormat(uiQuad->format));
+    VkImage dstImg = uiLayer.images[uiLayer.acquired].image;
+    Tempest::Attachment dst(*device, dstImg, uiQuad->width, uiQuad->height, toTexFormat(uiQuad->format));
+
+    struct DevAccess { Tempest::AbstractGraphicsApi& api; struct Impl { Tempest::AbstractGraphicsApi& api; Tempest::AbstractGraphicsApi::Device* dev; } impl; Tempest::AbstractGraphicsApi::Device* dev; };
+    auto& dx = *reinterpret_cast<Tempest::Detail::VDevice*>(reinterpret_cast<DevAccess*>(device)->dev);
+    auto cmd = dx.dataMgr().get();
+    cmd->begin(true);
+    auto& sTex = *reinterpret_cast<Tempest::Detail::VTexture*>(Tempest::textureCast<Tempest::Texture2d&>(src).impl.handler);
+    auto& dTex = *reinterpret_cast<Tempest::Detail::VTexture*>(Tempest::textureCast<Tempest::Texture2d&>(dst).impl.handler);
+    cmd->barrier(sTex, Tempest::ResourceAccess::ColorAttach, Tempest::ResourceAccess::TransferSrc, uint32_t(-1));
+    cmd->barrier(dTex, Tempest::ResourceAccess::None, Tempest::ResourceAccess::TransferDst, uint32_t(-1));
+    cmd->blit(sTex, uiQuad->width, uiQuad->height, 0, dTex, uiQuad->width, uiQuad->height, 0);
+    cmd->barrier(sTex, Tempest::ResourceAccess::TransferSrc, Tempest::ResourceAccess::Sampler, uint32_t(-1));
+    cmd->barrier(dTex, Tempest::ResourceAccess::TransferDst, Tempest::ResourceAccess::ColorAttach, uint32_t(-1));
+    cmd->end();
+    dx.dataMgr().submitAndWait(std::move(cmd));
+
     quadLayer.space = refSpace;
     quadLayer.pose.orientation = {uiQuad->orientation.x, uiQuad->orientation.y, uiQuad->orientation.z, uiQuad->orientation.w};
-    quadLayer.pose.position = {uiQuad->position.x, uiQuad->position.y, uiQuad->position.z};
+    quadLayer.pose.position    = {uiQuad->position.x, uiQuad->position.y, uiQuad->position.z};
     quadLayer.size = {uiQuad->metersWidth, uiQuad->metersWidth * float(uiQuad->height)/float(uiQuad->width)};
-    quadLayer.subImage.swapchain = XR_NULL_HANDLE;
+    quadLayer.subImage.swapchain = uiLayer.swapchain;
     quadLayer.subImage.imageRect.offset = {0,0};
     quadLayer.subImage.imageRect.extent = {uiQuad->width, uiQuad->height};
     layers[layerCount++] = reinterpret_cast<const XrCompositionLayerBaseHeader*>(&quadLayer);
@@ -526,6 +575,10 @@ void OpenXRBackend::endFrame() {
   ei.layerCount = layerCount;
   ei.layers = layers;
   xrEndFrame(session,&ei);
+  if(uiQuad) {
+    XrSwapchainImageReleaseInfo ri{XR_TYPE_SWAPCHAIN_IMAGE_RELEASE_INFO};
+    xrReleaseSwapchainImage(uiLayer.swapchain,&ri);
+  }
   uiQuad = nullptr;
 }
 
@@ -537,6 +590,14 @@ std::array<EyeInfo,2> OpenXRBackend::views() const {
     ret[i].color = eyes[i].color;
   }
   return ret;
+}
+
+Tempest::Vec3 OpenXRBackend::headPosition() const {
+  return toVec3(headPose.position);
+}
+
+Tempest::Vec4 OpenXRBackend::headOrientation() const {
+  return Tempest::Vec4{headPose.orientation.x, headPose.orientation.y, headPose.orientation.z, headPose.orientation.w};
 }
 
 void OpenXRBackend::pollInput() {

--- a/src/xr/OpenXRBackend.h
+++ b/src/xr/OpenXRBackend.h
@@ -21,6 +21,8 @@ public:
   const XRInputState& inputState() const override { return input; }
   void hapticPulse(float amplitude, float seconds) override;
   void setUiQuad(const XRQuadLayerDesc* desc) override { uiQuad = desc; }
+  Tempest::Vec3 headPosition() const override;
+  Tempest::Vec4 headOrientation() const override;
 
 private:
   struct Eye {
@@ -70,5 +72,14 @@ private:
   XrPath        handPath[2] = {XR_NULL_PATH,XR_NULL_PATH};
   XRInputState  input{};
   const XRQuadLayerDesc* uiQuad = nullptr;
+
+  struct UiLayer {
+    XrSwapchain                             swapchain = XR_NULL_HANDLE;
+    std::vector<XrSwapchainImageVulkan2KHR> images;
+    uint32_t                                width  = 0;
+    uint32_t                                height = 0;
+    VkFormat                                format = VK_FORMAT_UNDEFINED;
+    uint32_t                                acquired = 0;
+  } uiLayer;
 };
 #endif


### PR DESCRIPTION
## Summary
- export VR HUD offscreen image to Vulkan and copy into an internal OpenXR swapchain
- add head-following HUD pose with smoothing and pitch offset, plus right-hand laser-pointer that drives UI events
- document HUD follow options and laser pointer usage

## Testing
- `cmake -S . -B build` *(fails: /workspace/OpenGothic/lib/ZenKit does not contain a CMakeLists.txt file)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f5fde13883318c875bb412f54479