### PR TITLE
VR stability and comfort improvements

### DIFF
--- a/README_VR.md
+++ b/README_VR.md
@@ -45,6 +45,17 @@ Available options:
 - `--vr-hud-follow=on|off` – make the HUD follow the head (default `on`)
 - `--vr-hud-res-scale=<float>` – resolution scale for the offscreen HUD texture (default `1.0`)
 
+Additional tweaks:
+
+- `--vr-render-scale=<float>` – resolution scale for the 3D scene (default `1.0`)
+- `--vr-vignette-strength=<0..1>` – comfort vignette strength for the scene only (default `0`)
+- `--vr-recenter-hotkey=<key>` – recenter view to current head pose (default `R`)
+- `--vr-seated=on|off` – lower height for seated play (default `off`)
+- `--vr-dominant-hand=right|left` – choose hand for laser pointer and haptics (default `right`)
+- `--vr-log=<off|basic|verbose>` – control OpenXR logging verbosity (default `basic`)
+
+Vignette affects only the 3D world rendering, the HUD layer remains untouched. Recommended values for Quest 2/3: render-scale `1.0–1.2`, vignette-strength `0.15–0.3`, dominant-hand `right`, recenter hotkey `R`.
+
 ### Laser pointer & Follow
 
 Aim with the right-hand controller; the trigger (interact) maps to a mouse click on the HUD quad. The quad position can be tuned via `--vr-hud-distance`, `--vr-hud-width`, `--vr-hud-scale`, `--vr-hud-pitch-deg`, `--vr-hud-follow` and `--vr-hud-res-scale`. When follow is enabled, the quad smoothly tethers to head movement with gentle smoothing.

--- a/game/commandline.cpp
+++ b/game/commandline.cpp
@@ -4,6 +4,7 @@
 #include <Tempest/TextCodec>
 #include <cstring>
 #include <cassert>
+#include <cctype>
 
 #if defined(__APPLE__)
 #include <filesystem>
@@ -252,6 +253,91 @@ CommandLine::CommandLine(int argc, const char** argv) {
           vrVignette = std::stof(argv[++i]);
       } catch(...) {}
       vrVignette = std::clamp(vrVignette,0.f,1.f);
+    }
+    else if(arg.rfind("--vr-render-scale",0)==0) {
+      auto p = arg.find('=');
+      try {
+        if(p!=std::string_view::npos)
+          vrRenderScaleVal = std::stof(std::string(arg.substr(p+1)));
+        else if(i+1<argc)
+          vrRenderScaleVal = std::stof(argv[++i]);
+      } catch(...) {}
+      if(vrRenderScaleVal<0.1f) vrRenderScaleVal = 0.1f;
+    }
+    else if(arg.rfind("--vr-recenter-hotkey",0)==0) {
+      std::string val;
+      auto p = arg.find('=');
+      if(p!=std::string_view::npos)
+        val = std::string(arg.substr(p+1));
+      else if(i+1<argc)
+        val = argv[++i];
+      if(!val.empty()) {
+        char c = char(std::toupper(val[0]));
+        switch(c) {
+          case 'A': vrRecenterKeyVal = Tempest::Event::K_A; break;
+          case 'B': vrRecenterKeyVal = Tempest::Event::K_B; break;
+          case 'C': vrRecenterKeyVal = Tempest::Event::K_C; break;
+          case 'D': vrRecenterKeyVal = Tempest::Event::K_D; break;
+          case 'E': vrRecenterKeyVal = Tempest::Event::K_E; break;
+          case 'F': vrRecenterKeyVal = Tempest::Event::K_F; break;
+          case 'G': vrRecenterKeyVal = Tempest::Event::K_G; break;
+          case 'H': vrRecenterKeyVal = Tempest::Event::K_H; break;
+          case 'I': vrRecenterKeyVal = Tempest::Event::K_I; break;
+          case 'J': vrRecenterKeyVal = Tempest::Event::K_J; break;
+          case 'K': vrRecenterKeyVal = Tempest::Event::K_K; break;
+          case 'L': vrRecenterKeyVal = Tempest::Event::K_L; break;
+          case 'M': vrRecenterKeyVal = Tempest::Event::K_M; break;
+          case 'N': vrRecenterKeyVal = Tempest::Event::K_N; break;
+          case 'O': vrRecenterKeyVal = Tempest::Event::K_O; break;
+          case 'P': vrRecenterKeyVal = Tempest::Event::K_P; break;
+          case 'Q': vrRecenterKeyVal = Tempest::Event::K_Q; break;
+          case 'R': vrRecenterKeyVal = Tempest::Event::K_R; break;
+          case 'S': vrRecenterKeyVal = Tempest::Event::K_S; break;
+          case 'T': vrRecenterKeyVal = Tempest::Event::K_T; break;
+          case 'U': vrRecenterKeyVal = Tempest::Event::K_U; break;
+          case 'V': vrRecenterKeyVal = Tempest::Event::K_V; break;
+          case 'W': vrRecenterKeyVal = Tempest::Event::K_W; break;
+          case 'X': vrRecenterKeyVal = Tempest::Event::K_X; break;
+          case 'Y': vrRecenterKeyVal = Tempest::Event::K_Y; break;
+          case 'Z': vrRecenterKeyVal = Tempest::Event::K_Z; break;
+          default: break;
+        }
+      }
+    }
+    else if(arg.rfind("--vr-seated",0)==0) {
+      std::string val;
+      auto p = arg.find('=');
+      if(p!=std::string_view::npos)
+        val = std::string(arg.substr(p+1));
+      else if(i+1<argc)
+        val = argv[++i];
+      vrSeatedVal = (val=="on" || val=="1" || val=="true");
+    }
+    else if(arg.rfind("--vr-dominant-hand",0)==0) {
+      std::string val;
+      auto p = arg.find('=');
+      if(p!=std::string_view::npos)
+        val = std::string(arg.substr(p+1));
+      else if(i+1<argc)
+        val = argv[++i];
+      if(val=="left")
+        vrDominantHandVal = VrHand::Left;
+      else if(val=="right")
+        vrDominantHandVal = VrHand::Right;
+    }
+    else if(arg.rfind("--vr-log",0)==0) {
+      std::string val;
+      auto p = arg.find('=');
+      if(p!=std::string_view::npos)
+        val = std::string(arg.substr(p+1));
+      else if(i+1<argc)
+        val = argv[++i];
+      if(val=="off")
+        vrLogLevel = VrLog::Off;
+      else if(val=="verbose")
+        vrLogLevel = VrLog::Verbose;
+      else
+        vrLogLevel = VrLog::Basic;
     }
     else if(arg.rfind("--vr-hud-distance",0)==0) {
       auto p = arg.find('=');

--- a/game/commandline.h
+++ b/game/commandline.h
@@ -2,6 +2,7 @@
 
 #include <Tempest/Platform>
 #include <Tempest/Dir>
+#include <Tempest/Event>
 
 #include <cstdint>
 #include <stdexcept>
@@ -59,6 +60,13 @@ class CommandLine {
     int                 vrSnapCooldown()  const { return vrSnapCooldownVal;}
     float               vrMoveSpeedScale()const { return vrMoveScale;   }
     float               vrVignetteStrength() const { return vrVignette; }
+    float               vrRenderScale()   const { return vrRenderScaleVal; }
+    Tempest::Event::KeyType vrRecenterKey() const { return vrRecenterKeyVal; }
+    bool                vrSeated()        const { return vrSeatedVal; }
+    enum class VrHand { Left, Right };
+    VrHand             vrDominantHand() const { return vrDominantHandVal; }
+    enum class VrLog { Off, Basic, Verbose };
+    VrLog              vrLog() const { return vrLogLevel; }
 
       // VR HUD parameters
       float               vrHudDistance()   const { return vrHudDist;    }
@@ -111,6 +119,11 @@ class CommandLine {
     int                 vrSnapCooldownVal= 250;
     float               vrMoveScale   = 1.f;
     float               vrVignette    = 0.f;
+    float               vrRenderScaleVal = 1.f;
+    Tempest::Event::KeyType vrRecenterKeyVal = Tempest::Event::K_R;
+    bool                vrSeatedVal   = false;
+    VrHand              vrDominantHandVal = VrHand::Right;
+    VrLog               vrLogLevel = VrLog::Basic;
     float               vrHudDist     = 1.4f;
     float               vrHudWidthVal = 1.0f;
     float               vrHudScaleVal = 1.0f;

--- a/game/graphics/renderer.cpp
+++ b/game/graphics/renderer.cpp
@@ -11,6 +11,10 @@
 #include "camera.h"
 #include "gothic.h"
 #include "utils/string_frm.h"
+#include "../commandline.h"
+#ifdef OPENXR_ENABLED
+#include "shader.h"
+#endif
 
 using namespace Tempest;
 
@@ -98,6 +102,22 @@ Renderer::Renderer(Tempest::Swapchain& swapchain)
   sky.viewLut       = device.attachment(Tempest::TextureFormat::RGBA32F, 128, 64);
   sky.viewCldLut    = device.attachment(Tempest::TextureFormat::RGBA32F, 512, 256);
   sky.irradianceLut = device.image2d(TextureFormat::RGBA32F, 3,2);
+
+#ifdef OPENXR_ENABLED
+  if(CommandLine::inst().isVr()) {
+    RenderState st;
+    st.setZTestMode(RenderState::ZTestMode::Always);
+    st.setZWriteEnabled(false);
+    st.setBlendSource(RenderState::BlendMode::Zero);
+    st.setBlendDest  (RenderState::BlendMode::SrcColor);
+    auto sh = GothicShader::get("triangle_uv.vert.sprv");
+    auto vs = device.shader(sh.data,sh.len);
+    sh      = GothicShader::get("vr_vignette.frag.sprv");
+    auto fs = device.shader(sh.data,sh.len);
+    vrVignettePso = device.pipeline(Triangles, st, vs, fs);
+    vrVignetteInner = 1.f - CommandLine::inst().vrVignetteStrength()*0.4f;
+  }
+#endif
 
   setupSettings();
   }
@@ -631,10 +651,21 @@ void Renderer::draw(Tempest::Attachment& result, Encoder<CommandBuffer>& cmd, ui
   if(settings.aaEnabled) {
     cmd.setDebugMarker("CMAA2 & Tonemapping");
     drawCMAA2(result, cmd, *wview);
-    } else {
+  } else {
     cmd.setDebugMarker("Tonemapping");
     drawTonemapping(result, cmd, *wview);
-    }
+  }
+
+#ifdef OPENXR_ENABLED
+  if(CommandLine::inst().isVr() && vrVignetteInner < 0.999f) {
+    struct Push { float inner = 1.f; } p;
+    p.inner = vrVignetteInner;
+    cmd.setFramebuffer({{result, Tempest::Preserve, Tempest::Preserve}});
+    cmd.setPushData(p);
+    cmd.setPipeline(vrVignettePso);
+    cmd.draw(nullptr,0,3);
+  }
+#endif
 
   wview->postFrameupdate();
   }

--- a/game/graphics/renderer.h
+++ b/game/graphics/renderer.h
@@ -198,6 +198,11 @@ class Renderer final {
       bool                      fisrtFrame = false;
       } gi;
 
+#ifdef OPENXR_ENABLED
+    Tempest::RenderPipeline    vrVignettePso;
+    float                      vrVignetteInner = 1.f;
+#endif
+
     struct {
       Tempest::StorageBuffer    epipoles;
       Tempest::StorageImage     epTrace;

--- a/game/mainwindow.cpp
+++ b/game/mainwindow.cpp
@@ -475,6 +475,11 @@ void MainWindow::keyDownEvent(KeyEvent &event) {
 
   if(xrBackend_!=nullptr) {
     float step = CommandLine::inst().vrSnapAngle()*float(M_PI/180.f);
+    if(event.key==CommandLine::inst().vrRecenterKey()) {
+      xrBackend_->recenter();
+      event.accept();
+      return;
+    }
     if(event.key==Event::K_Q) {
       vrSnapYaw -= step;
       event.accept();
@@ -903,12 +908,21 @@ void MainWindow::onMarvinKey() {
   }
 
 uint64_t MainWindow::tick() {
-  auto time = Application::tickCount();
-  auto dt   = time-lastTick;
-  // NOTE: limit to ~200 FPS in game logic to avoid math issues
-  if(dt<5)
-    return 0;
-  lastTick  = time;
+  uint64_t dt = 0;
+  if(xrBackend_!=nullptr) {
+    if(!xrBackend_->isVisible())
+      return 0;
+    dt = uint64_t(xrBackend_->xrDeltaSeconds()*1000.0);
+    if(dt==0)
+      return 0;
+    lastTick = Application::tickCount();
+  } else {
+    auto time = Application::tickCount();
+    dt = time-lastTick;
+    if(dt<5)
+      return 0;
+    lastTick = time;
+  }
 
   auto st = Gothic::inst().checkLoading();
   if(st==Gothic::LoadState::Finalize || st==Gothic::LoadState::FailedLoad || st==Gothic::LoadState::FailedSave) {
@@ -1387,10 +1401,13 @@ void MainWindow::render(){
         cmdId = (cmdId+1u)%Resources::MaxFramesInFlight;
         return;
       } else {
-        xrBackend_->shutdown();
-        delete xrBackend_;
-        xrBackend_ = nullptr;
-        vrSnapYaw = 0.f;
+        if(!xrBackend_->isRunning()) {
+          xrBackend_->shutdown();
+          delete xrBackend_;
+          xrBackend_ = nullptr;
+          vrSnapYaw = 0.f;
+        }
+        return;
       }
     }
 

--- a/include/xr/IXRBackend.h
+++ b/include/xr/IXRBackend.h
@@ -38,6 +38,11 @@ public:
   virtual void setUiQuad(const XRQuadLayerDesc* q) = 0; // nullptr clears for this frame
 #endif
 
+  virtual bool   isVisible() const = 0;
+  virtual bool   isRunning() const = 0;
+  virtual double xrDeltaSeconds() const = 0;
+  virtual void   recenter() = 0;
+
   virtual Tempest::Vec3 headPosition() const = 0;
   virtual Tempest::Vec4 headOrientation() const = 0;
 

--- a/shader/vr_vignette.frag
+++ b/shader/vr_vignette.frag
@@ -1,0 +1,16 @@
+#version 450
+#extension GL_ARB_separate_shader_objects : enable
+
+layout(push_constant, std140) uniform Push {
+  float inner;
+} push;
+
+layout(location = 0) in vec2 uv;
+layout(location = 0) out vec4 outColor;
+
+void main() {
+  vec2 c = uv*2.0 - 1.0;
+  float r = length(c);
+  float m = smoothstep(push.inner, 1.0, r);
+  outColor = vec4(1.0 - m);
+}

--- a/src/xr/OpenXRBackend.cpp
+++ b/src/xr/OpenXRBackend.cpp
@@ -13,6 +13,8 @@
 #include <vector>
 #include <algorithm>
 #include <cmath>
+#include <thread>
+#include <chrono>
 
 namespace {
 
@@ -159,6 +161,106 @@ OpenXRBackend::~OpenXRBackend() {
   shutdown();
 }
 
+bool OpenXRBackend::createSwapchains() {
+  for(auto& e:eyes) {
+    if(e.swapchain!=XR_NULL_HANDLE) {
+      xrDestroySwapchain(e.swapchain);
+      e.swapchain = XR_NULL_HANDLE;
+      e.images.clear();
+    }
+    e.width  = uint32_t(float(e.baseWidth )*renderScale);
+    e.height = uint32_t(float(e.baseHeight)*renderScale);
+
+    XrSwapchainCreateInfo sc{XR_TYPE_SWAPCHAIN_CREATE_INFO};
+    sc.usageFlags  = XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT | XR_SWAPCHAIN_USAGE_SAMPLED_BIT;
+    sc.format      = e.format;
+    sc.sampleCount = e.sampleCount;
+    sc.width       = e.width;
+    sc.height      = e.height;
+    sc.faceCount   = 1;
+    sc.arraySize   = 1;
+    sc.mipCount    = 1;
+
+    if(xrCreateSwapchain(session,&sc,&e.swapchain)!=XR_SUCCESS)
+      return false;
+
+    uint32_t imgCount = 0;
+    xrEnumerateSwapchainImages(e.swapchain,0,&imgCount,nullptr);
+    e.images.resize(imgCount, {XR_TYPE_SWAPCHAIN_IMAGE_VULKAN2_KHR});
+    xrEnumerateSwapchainImages(e.swapchain,imgCount,&imgCount,(XrSwapchainImageBaseHeader*)e.images.data());
+
+    if(logLevel!=LogLevel::Off)
+      Tempest::Log::i("Eye ", int(&e-&eyes[0]), ": ", e.width, "x", e.height);
+  }
+  return true;
+}
+
+void OpenXRBackend::destroySwapchains() {
+  for(auto& e:eyes) {
+    e.color = {};
+    if(e.swapchain!=XR_NULL_HANDLE)
+      xrDestroySwapchain(e.swapchain);
+    e.swapchain = XR_NULL_HANDLE;
+    e.images.clear();
+  }
+}
+
+void OpenXRBackend::pollEvents() {
+  XrEventDataBuffer ev{XR_TYPE_EVENT_DATA_BUFFER};
+  while(xrPollEvent(instance, &ev)==XR_SUCCESS) {
+    if(ev.type==XR_TYPE_EVENT_DATA_SESSION_STATE_CHANGED) {
+      auto& ssc = *reinterpret_cast<XrEventDataSessionStateChanged*>(&ev);
+      switch(ssc.state) {
+        case XR_SESSION_STATE_READY: {
+          XrSessionBeginInfo bi{XR_TYPE_SESSION_BEGIN_INFO};
+          bi.primaryViewConfigurationType = XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;
+          xrBeginSession(session,&bi);
+          state = SessionState::Ready;
+          running = true;
+          break;
+        }
+        case XR_SESSION_STATE_SYNCHRONIZED:
+          state = SessionState::Synchronized;
+          visible = false;
+          running = true;
+          break;
+        case XR_SESSION_STATE_VISIBLE:
+          state = SessionState::Visible;
+          visible = true;
+          running = true;
+          break;
+        case XR_SESSION_STATE_FOCUSED:
+          state = SessionState::Focused;
+          visible = true;
+          running = true;
+          break;
+        case XR_SESSION_STATE_STOPPING:
+          xrEndSession(session);
+          state = SessionState::Stopping;
+          visible = false;
+          running = false;
+          break;
+        case XR_SESSION_STATE_EXITING:
+        case XR_SESSION_STATE_LOSS_PENDING:
+          state = SessionState::Exiting;
+          visible = false;
+          running = false;
+          break;
+        case XR_SESSION_STATE_IDLE:
+          state = SessionState::Idle;
+          visible = false;
+          running = false;
+          break;
+        default:
+          break;
+      }
+      if(logLevel==LogLevel::Verbose)
+        Tempest::Log::d("XR state ", int(ssc.state));
+    }
+    ev = {XR_TYPE_EVENT_DATA_BUFFER};
+  }
+}
+
 bool OpenXRBackend::initialize(Tempest::Device& dev, Tempest::Window& win) {
   (void)win;
   device = &dev;
@@ -166,7 +268,13 @@ bool OpenXRBackend::initialize(Tempest::Device& dev, Tempest::Window& win) {
   auto& cmd = CommandLine::inst();
   firstPerson  = cmd.isVrFirstPerson();
   heightOffset = cmd.vrHeightOffset();
-  allowRoll    = cmd.vrAllowRoll();
+  if(cmd.vrSeated())
+    heightOffset -= 0.5f;
+  allowRoll     = cmd.vrAllowRoll();
+  dominantHand  = (cmd.vrDominantHand()==CommandLine::VrHand::Left ? 0u : 1u);
+  renderScale   = cmd.vrRenderScale();
+  logLevel      = cmd.vrLog();
+  turnDeadzone  = cmd.vrTurnDeadzone();
 
   uint32_t extCount = 0;
   xrEnumerateInstanceExtensionProperties(nullptr, 0, &extCount, nullptr);
@@ -193,6 +301,12 @@ bool OpenXRBackend::initialize(Tempest::Device& dev, Tempest::Window& win) {
   XrInstanceProperties ip{XR_TYPE_INSTANCE_PROPERTIES};
   if(xrGetInstanceProperties(instance,&ip)==XR_SUCCESS)
     Tempest::Log::i("OpenXR runtime: ", ip.runtimeName);
+
+  if(logLevel!=LogLevel::Off) {
+    Tempest::Log::i("VR render scale: ", renderScale);
+    Tempest::Log::i("VR vignette strength: ", cmd.vrVignetteStrength());
+    Tempest::Log::i("VR dominant hand: ", dominantHand==1?"right":"left");
+  }
 
   xrGetInstanceProcAddr(instance,"xrGetVulkanInstanceExtensionsKHR", (PFN_xrVoidFunction*)&pfnGetInstanceExtensions);
   xrGetInstanceProcAddr(instance,"xrGetVulkanDeviceExtensionsKHR",   (PFN_xrVoidFunction*)&pfnGetDeviceExtensions);
@@ -277,8 +391,8 @@ bool OpenXRBackend::initialize(Tempest::Device& dev, Tempest::Window& win) {
   makeAction(interactAction, XR_ACTION_TYPE_BOOLEAN_INPUT, "interact", "Interact");
   makeAction(menuAction, XR_ACTION_TYPE_BOOLEAN_INPUT, "menu", "Menu");
   makeAction(teleportAction, XR_ACTION_TYPE_BOOLEAN_INPUT, "teleport_click", "Teleport");
-  makeAction(aimPoseAction, XR_ACTION_TYPE_POSE_INPUT, "aim_pose", "Aim Pose", &handPath[1],1);
-  makeAction(hapticAction, XR_ACTION_TYPE_VIBRATION_OUTPUT, "haptic", "Haptic", &handPath[1],1);
+  makeAction(aimPoseAction, XR_ACTION_TYPE_POSE_INPUT, "aim_pose", "Aim Pose", handPath.data(),uint32_t(handPath.size()));
+  makeAction(hapticAction, XR_ACTION_TYPE_VIBRATION_OUTPUT, "haptic", "Haptic", handPath.data(),uint32_t(handPath.size()));
 
   auto path = [&](const char* s) { return stringToPath(instance,s); };
   std::vector<XrActionSuggestedBinding> oculus = {
@@ -290,7 +404,9 @@ bool OpenXRBackend::initialize(Tempest::Device& dev, Tempest::Window& win) {
     {attackAction,    path("/user/hand/right/input/trigger/click")},
     {teleportAction,  path("/user/hand/left/input/trigger/click")},
     {aimPoseAction,   path("/user/hand/right/input/aim/pose")},
-    {hapticAction,    path("/user/hand/right/output/haptic")}
+    {aimPoseAction,   path("/user/hand/left/input/aim/pose")},
+    {hapticAction,    path("/user/hand/right/output/haptic")},
+    {hapticAction,    path("/user/hand/left/output/haptic")}
   };
   XrInteractionProfileSuggestedBinding suggested{XR_TYPE_INTERACTION_PROFILE_SUGGESTED_BINDING};
   suggested.interactionProfile = path("/interaction_profiles/oculus/touch_controller");
@@ -309,7 +425,9 @@ bool OpenXRBackend::initialize(Tempest::Device& dev, Tempest::Window& win) {
       {attackAction,    path("/user/hand/right/input/trigger/click")},
       {teleportAction,  path("/user/hand/left/input/trigger/click")},
       {aimPoseAction,   path("/user/hand/right/input/aim/pose")},
-      {hapticAction,    path("/user/hand/right/output/haptic")}
+      {aimPoseAction,   path("/user/hand/left/input/aim/pose")},
+      {hapticAction,    path("/user/hand/right/output/haptic")},
+      {hapticAction,    path("/user/hand/left/output/haptic")}
     };
     XrInteractionProfileSuggestedBinding sb{XR_TYPE_INTERACTION_PROFILE_SUGGESTED_BINDING};
     sb.interactionProfile = wmrProfile;
@@ -323,11 +441,13 @@ bool OpenXRBackend::initialize(Tempest::Device& dev, Tempest::Window& win) {
   attach.actionSets      = &actionSet;
   xrAttachSessionActionSets(session,&attach);
 
-  XrActionSpaceCreateInfo asci2{XR_TYPE_ACTION_SPACE_CREATE_INFO};
-  asci2.action = aimPoseAction;
-  asci2.subactionPath = handPath[1];
-  asci2.poseInActionSpace.orientation.w = 1.f;
-  xrCreateActionSpace(session,&asci2,&aimSpace);
+  for(size_t i=0;i<2;++i) {
+    XrActionSpaceCreateInfo asci2{XR_TYPE_ACTION_SPACE_CREATE_INFO};
+    asci2.action = aimPoseAction;
+    asci2.subactionPath = handPath[i];
+    asci2.poseInActionSpace.orientation.w = 1.f;
+    xrCreateActionSpace(session,&asci2,&aimSpace[i]);
+  }
 
   Tempest::Log::i("View configuration: PRIMARY_STEREO");
 
@@ -345,54 +465,33 @@ bool OpenXRBackend::initialize(Tempest::Device& dev, Tempest::Window& win) {
   Tempest::Log::i("Swapchain format: ", int(colorFormat));
 
   for(uint32_t i=0;i<viewCount && i<eyes.size();++i) {
-    eyes[i].width  = cfg[i].recommendedImageRectWidth;
-    eyes[i].height = cfg[i].recommendedImageRectHeight;
-    eyes[i].format = colorFormat;
+    eyes[i].baseWidth   = cfg[i].recommendedImageRectWidth;
+    eyes[i].baseHeight  = cfg[i].recommendedImageRectHeight;
+    eyes[i].sampleCount = cfg[i].recommendedSwapchainSampleCount;
+    eyes[i].format      = colorFormat;
+  }
 
-    XrSwapchainCreateInfo sc{XR_TYPE_SWAPCHAIN_CREATE_INFO};
-    sc.usageFlags   = XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT | XR_SWAPCHAIN_USAGE_SAMPLED_BIT;
-    sc.format       = colorFormat;
-    sc.sampleCount  = cfg[i].recommendedSwapchainSampleCount;
-    sc.width        = eyes[i].width;
-    sc.height       = eyes[i].height;
-    sc.faceCount    = 1;
-    sc.arraySize    = 1;
-    sc.mipCount     = 1;
-
-    if(xrCreateSwapchain(session,&sc,&eyes[i].swapchain)!=XR_SUCCESS) {
-      Tempest::Log::e("xrCreateSwapchain failed");
-      shutdown();
-      return false;
-    }
-
-    uint32_t imgCount = 0;
-    xrEnumerateSwapchainImages(eyes[i].swapchain,0,&imgCount,nullptr);
-    eyes[i].images.resize(imgCount, {XR_TYPE_SWAPCHAIN_IMAGE_VULKAN2_KHR});
-    xrEnumerateSwapchainImages(eyes[i].swapchain,imgCount,&imgCount,(XrSwapchainImageBaseHeader*)eyes[i].images.data());
-
-    Tempest::Log::i("Eye ", i, ": ", eyes[i].width, "x", eyes[i].height, " format ", int(colorFormat));
+  if(!createSwapchains()) {
+    shutdown();
+    return false;
   }
 
   return true;
 }
 
 void OpenXRBackend::shutdown() {
-  for(auto& e:eyes) {
-    e.color = {};
-    if(e.swapchain!=XR_NULL_HANDLE)
-      xrDestroySwapchain(e.swapchain);
-    e.swapchain = XR_NULL_HANDLE;
-  }
+  destroySwapchains();
   if(uiSwapchain!=XR_NULL_HANDLE) {
     xrDestroySwapchain(uiSwapchain);
     uiSwapchain = XR_NULL_HANDLE;
   }
   uiImages.clear();
   haveUi = false;
-  if(aimSpace!=XR_NULL_HANDLE) {
-    xrDestroySpace(aimSpace);
-    aimSpace = XR_NULL_HANDLE;
-  }
+  for(auto& sp:aimSpace)
+    if(sp!=XR_NULL_HANDLE) {
+      xrDestroySpace(sp);
+      sp = XR_NULL_HANDLE;
+    }
   if(actionSet!=XR_NULL_HANDLE) {
     xrDestroyActionSet(actionSet);
     actionSet = XR_NULL_HANDLE;
@@ -419,12 +518,28 @@ bool OpenXRBackend::beginFrame() {
   if(session==XR_NULL_HANDLE)
     return false;
 
+  pollEvents();
+  if(!running || !visible) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    return false;
+  }
+
   XrFrameWaitInfo wi{XR_TYPE_FRAME_WAIT_INFO};
   if(xrWaitFrame(session,&wi,&frameState)!=XR_SUCCESS)
     return false;
   XrFrameBeginInfo bi{XR_TYPE_FRAME_BEGIN_INFO};
   if(xrBeginFrame(session,&bi)!=XR_SUCCESS)
     return false;
+
+  if(lastPredicted!=0) {
+    dt = double(frameState.predictedDisplayTime - lastPredicted) / 1e9;
+    dt = std::clamp(dt, 1.0/144.0, 1.0/30.0);
+    if(!loggedFps && logLevel!=LogLevel::Off) {
+      Tempest::Log::i("XR refresh rate: ", int(std::round(1.0/dt)), " Hz");
+      loggedFps = true;
+    }
+  }
+  lastPredicted = frameState.predictedDisplayTime;
 
   XrSpaceLocation headLoc{XR_TYPE_SPACE_LOCATION};
   if(xrLocateSpace(headSpace, refSpace, frameState.predictedDisplayTime, &headLoc)==XR_SUCCESS) {
@@ -625,6 +740,20 @@ void OpenXRBackend::pollInput() {
   if(xrSyncActions(session,&sync)!=XR_SUCCESS)
     return;
 
+  if(!profileQueried) {
+    XrInteractionProfileState prof{XR_TYPE_INTERACTION_PROFILE_STATE};
+    if(xrGetCurrentInteractionProfile(session, handPath[dominantHand], &prof)==XR_SUCCESS && prof.interactionProfile!=XR_NULL_PATH) {
+      char path[XR_MAX_PATH_LENGTH] = {};
+      uint32_t sz = 0;
+      xrPathToString(instance, prof.interactionProfile, XR_MAX_PATH_LENGTH, &sz, path);
+      if(std::strstr(path, "simple_controller")!=nullptr)
+        simpleController = true;
+    }
+    profileQueried = true;
+    if(simpleController && turnDeadzone<=0.25f)
+      turnDeadzone = 0.3f;
+  }
+
   XrActionStateGetInfo gi{XR_TYPE_ACTION_STATE_GET_INFO};
   XrActionStateVector2f v2{XR_TYPE_ACTION_STATE_VECTOR2F};
   gi.action = moveAction;
@@ -638,7 +767,10 @@ void OpenXRBackend::pollInput() {
   xrGetActionStateVector2f(session,&gi,&v2);
   if(v2.isActive) {
     input.haveControllers = true;
-    input.turnX = v2.currentState.x;
+    float x = v2.currentState.x;
+    if(std::fabs(x) < turnDeadzone)
+      x = 0.f;
+    input.turnX = x;
   }
 
   XrActionStateBoolean b{XR_TYPE_ACTION_STATE_BOOLEAN};
@@ -662,16 +794,23 @@ void OpenXRBackend::pollInput() {
   xrGetActionStateBoolean(session,&gi,&b);
   input.teleportClick = b.currentState;
 
-  if(aimSpace!=XR_NULL_HANDLE) {
+  size_t handIdx = dominantHand;
+  for(int attempt=0; attempt<2; ++attempt) {
+    if(aimSpace[handIdx]==XR_NULL_HANDLE) {
+      handIdx = 1 - handIdx;
+      continue;
+    }
     XrSpaceLocation loc{XR_TYPE_SPACE_LOCATION};
-    if(xrLocateSpace(aimSpace, refSpace, frameState.predictedDisplayTime, &loc)==XR_SUCCESS) {
+    if(xrLocateSpace(aimSpace[handIdx], refSpace, frameState.predictedDisplayTime, &loc)==XR_SUCCESS) {
       const XrSpaceLocationFlags req = XR_SPACE_LOCATION_POSITION_VALID_BIT | XR_SPACE_LOCATION_ORIENTATION_VALID_BIT;
       if((loc.locationFlags & req)==req) {
         input.aim.valid = true;
         input.aim.pos   = toVec3(loc.pose.position);
         input.aim.dir   = rotate(loc.pose.orientation, Tempest::Vec3{0,0,-1});
+        break;
       }
     }
+    handIdx = 1 - handIdx;
   }
 }
 
@@ -684,8 +823,31 @@ void OpenXRBackend::hapticPulse(float amplitude, float seconds) {
   vib.frequency = XR_FREQUENCY_UNSPECIFIED;
   XrHapticActionInfo hi{XR_TYPE_HAPTIC_ACTION_INFO};
   hi.action = hapticAction;
-  hi.subactionPath = handPath[1];
+  hi.subactionPath = handPath[dominantHand];
   xrApplyHapticFeedback(session,&hi,(XrHapticBaseHeader*)&vib);
+}
+
+bool OpenXRBackend::isVisible() const {
+  return visible;
+}
+
+bool OpenXRBackend::isRunning() const {
+  return running;
+}
+
+void OpenXRBackend::recenter() {
+  if(session==XR_NULL_HANDLE)
+    return;
+  XrPosef p{};
+  p.orientation.w = 1.f;
+  xrResetReferenceSpace(session, XR_REFERENCE_SPACE_TYPE_LOCAL, &p);
+}
+
+void OpenXRBackend::setRenderScale(float s) {
+  if(s<=0.f || std::fabs(s-renderScale)<1e-3f)
+    return;
+  renderScale = s;
+  createSwapchains();
 }
 
 #endif

--- a/src/xr/OpenXRBackend.h
+++ b/src/xr/OpenXRBackend.h
@@ -24,18 +24,43 @@ public:
   Tempest::Vec3 headPosition() const override;
   Tempest::Vec4 headOrientation() const override;
 
+  bool   isVisible() const override;
+  bool   isRunning() const override;
+  double xrDeltaSeconds() const override { return dt; }
+  void   recenter() override;
+  void   setRenderScale(float s);
+
 private:
   struct Eye {
     XrSwapchain                             swapchain = XR_NULL_HANDLE;
     std::vector<XrSwapchainImageVulkan2KHR> images;
     uint32_t                                width  = 0;
     uint32_t                                height = 0;
+    uint32_t                                baseWidth  = 0;
+    uint32_t                                baseHeight = 0;
+    uint32_t                                sampleCount = 1;
     VkFormat                                format = VK_FORMAT_R8G8B8A8_UNORM;
     uint32_t                                acquired = 0;
     XrView                                  view{XR_TYPE_VIEW};
     Tempest::Matrix4x4                      viewMat;
     Tempest::Matrix4x4                      projMat;
     Tempest::Attachment                     color; // per-frame wrapped image
+  };
+
+  enum class SessionState : uint8_t {
+    Idle,
+    Ready,
+    Synchronized,
+    Visible,
+    Focused,
+    Stopping,
+    Exiting,
+  };
+
+  enum class LogLevel : uint8_t {
+    Off,
+    Basic,
+    Verbose,
   };
 
   Tempest::Device* device = nullptr;
@@ -68,9 +93,22 @@ private:
   XrAction      teleportAction=XR_NULL_HANDLE;
   XrAction      aimPoseAction=XR_NULL_HANDLE;
   XrAction      hapticAction=XR_NULL_HANDLE;
-  XrSpace       aimSpace    = XR_NULL_HANDLE;
+  XrSpace       aimSpace[2] = {XR_NULL_HANDLE,XR_NULL_HANDLE};
   XrPath        handPath[2] = {XR_NULL_PATH,XR_NULL_PATH};
   XRInputState  input{};
+
+  SessionState  state       = SessionState::Idle;
+  LogLevel      logLevel    = LogLevel::Basic;
+  bool          visible     = false;
+  bool          running     = false;
+  double        dt          = 0.0;
+  XrTime        lastPredicted = 0;
+  bool          loggedFps   = false;
+  float         renderScale = 1.f;
+  size_t        dominantHand = 1;
+  bool          simpleController = false;
+  float         turnDeadzone = 0.25f;
+  bool          profileQueried = false;
 
   XRQuadLayerDesc uiReq{};
   bool            haveUi = false;
@@ -79,5 +117,9 @@ private:
   int                                     uiW = 0;
   int                                     uiH = 0;
   std::vector<XrSwapchainImageVulkan2KHR> uiImages;
+
+  bool createSwapchains();
+  void destroySwapchains();
+  void pollEvents();
 };
 #endif


### PR DESCRIPTION
## Summary
- Implement OpenXR session state machine with pause/resume and predicted display timing
- Add comfort vignette post-pass and configurable scene render scale
- Support recenter hotkey, seated mode, dominant hand routing, and extended VR CLI options

## Testing
- `cmake -S . -B build` *(fails: glslangValidator required / missing subprojects)*
- `apt-get install -y glslang-tools`
- `cmake -S . -B build` *(fails: missing Tempest/Bullet subdirectories)*


------
https://chatgpt.com/codex/tasks/task_e_68c604103e1483318460ba915b42bfd2