### PR TITLE
Integrate VR locomotion with physics

### DIFF
--- a/README_VR.md
+++ b/README_VR.md
@@ -40,6 +40,8 @@ Additional options:
 - `--vr-teleport-max-slope=<deg>` – reject teleport to steep surfaces (default `45`)
 - `--vr-walk-step=<meters>` – step offset for collision (default `0.30`)
 - `--vr-walk-slope=<deg>` – maximum walkable slope (default `45`)
+- `--vr-walk-accel=<m/s^2>` – walk acceleration (default `10`)
+- `--vr-walk-maxspeed=<m/s>` – walk speed clamp (default `3`)
 - `--vr-keep-heading=on|off` – keep controller yaw on teleport (default `on`)
 - `--vr-ui-scroll-scale=<float>` – scroll wheel scale for HUD laser (default `1.0`)
 - `--vr-ui-longpress=<sec>` – hold duration for context click (default `0.45`)
@@ -94,3 +96,11 @@ Squeeze a controller to grab nearby objects tagged for VR (name prefix `vr_picku
 Held objects follow the controller grip and can be dropped or thrown by releasing the squeeze.
 Teleport rays snap to the first walkable surface when `--vr-teleport-grounded=on`.
 Too-steep or invalid targets are rejected with a brief haptic tick.
+
+## Locomotion internals
+
+All movement is routed through the original Gothic character controller via the `VRLocomotion` module. The left stick builds a
+desired velocity which is limited by `--vr-walk-accel` (default `10 m/s²`) and `--vr-walk-maxspeed` (default `3 m/s`). The
+`VRCharacter` adapter performs collision checks and passes the corrected motion to the game physics. Teleports are validated by
+`VRNav` before warping the player. Turning supports both snap and smooth modes and is applied through the player controller so
+non-VR behaviour is preserved.

--- a/game/commandline.cpp
+++ b/game/commandline.cpp
@@ -545,6 +545,24 @@ CommandLine::CommandLine(int argc, const char** argv) {
           vrWalkSlopeVal = std::stof(argv[++i]);
       } catch(...) {}
     }
+    else if(arg.rfind("--vr-walk-accel",0)==0) {
+      auto p = arg.find('=');
+      try {
+        if(p!=std::string_view::npos)
+          vrWalkAccelVal = std::stof(std::string(arg.substr(p+1)));
+        else if(i+1<argc)
+          vrWalkAccelVal = std::stof(argv[++i]);
+      } catch(...) {}
+    }
+    else if(arg.rfind("--vr-walk-maxspeed",0)==0) {
+      auto p = arg.find('=');
+      try {
+        if(p!=std::string_view::npos)
+          vrWalkMaxSpeedVal = std::stof(std::string(arg.substr(p+1)));
+        else if(i+1<argc)
+          vrWalkMaxSpeedVal = std::stof(argv[++i]);
+      } catch(...) {}
+    }
     else if(arg.rfind("--vr-keep-heading",0)==0) {
       auto p = arg.find('=');
       if(p!=std::string_view::npos) {

--- a/game/commandline.h
+++ b/game/commandline.h
@@ -84,6 +84,8 @@ class CommandLine {
     bool               vrHaptics() const { return vrHapticsVal; }
     float              vrWalkStep() const { return vrWalkStepVal; }
     float              vrWalkSlope() const { return vrWalkSlopeVal; }
+    float              vrWalkAccel() const { return vrWalkAccelVal; }
+    float              vrWalkMaxSpeed() const { return vrWalkMaxSpeedVal; }
     bool               vrKeepHeading() const { return vrKeepHeadingVal; }
     float              vrUiScrollScale() const { return vrUiScrollScaleVal; }
     float              vrUiLongPress() const { return vrUiLongPressVal; }
@@ -165,6 +167,8 @@ class CommandLine {
     bool                vrHapticsVal = true;
     float               vrWalkStepVal = 0.3f;
     float               vrWalkSlopeVal = 45.f;
+    float               vrWalkAccelVal = 10.f;
+    float               vrWalkMaxSpeedVal = 3.f;
     bool                vrKeepHeadingVal = true;
     float               vrUiScrollScaleVal = 1.f;
     float               vrUiLongPressVal = 0.45f;

--- a/game/game/playercontrol.cpp
+++ b/game/game/playercontrol.cpp
@@ -539,13 +539,47 @@ bool PlayerControl::tickCameraMove(uint64_t dt) {
   return true;
   }
 
-void PlayerControl::setVrMove(float strafe, float forward) {
-  movement.strafeRightLeft.analog = std::clamp(strafe,-1.f,1.f);
-  movement.forwardBackward.analog = std::clamp(forward,-1.f,1.f);
+Tempest::Vec3 PlayerControl::getWorldPos() const {
+  auto w = Gothic::inst().world();
+  auto pl = w ? w->player() : nullptr;
+  return pl ? pl->position() : Tempest::Vec3{};
 }
 
-void PlayerControl::setVrTurn(float turn) {
-  movement.turnRightLeft.analog = std::clamp(turn,-1.f,1.f);
+float PlayerControl::getYaw() const {
+  auto w = Gothic::inst().world();
+  auto pl = w ? w->player() : nullptr;
+  return pl ? pl->rotationRad() : 0.f;
+}
+
+bool PlayerControl::isOnGround() const {
+  auto w = Gothic::inst().world();
+  auto pl = w ? w->player() : nullptr;
+  return pl ? !pl->isInAir() : true;
+}
+
+void PlayerControl::vrSetWorldPose(const Tempest::Vec3& pos, float yawRad) {
+  auto w = Gothic::inst().world();
+  auto pl = w ? w->player() : nullptr;
+  if(pl) {
+    pl->setPosition(pos);
+    pl->setDirection(yawRad*180.f/float(M_PI));
+  }
+}
+
+void PlayerControl::vrMoveDelta(const Tempest::Vec3& delta) {
+  auto w = Gothic::inst().world();
+  auto pl = w ? w->player() : nullptr;
+  if(pl)
+    pl->tryMove(delta);
+}
+
+void PlayerControl::vrRotateYaw(float yawRad) {
+  auto w = Gothic::inst().world();
+  auto pl = w ? w->player() : nullptr;
+  if(pl) {
+    float yaw = pl->rotation() + yawRad*180.f/float(M_PI);
+    pl->setDirection(yaw);
+  }
 }
 
 void PlayerControl::setVrButton(KeyCodec::Action a, bool v) {
@@ -673,23 +707,6 @@ void PlayerControl::implMove(uint64_t dt) {
   if(bs==BS_UNCONSCIOUS)
     return;
 
-#ifdef OPENXR_ENABLED
-  if(CommandLine::inst().isVr()) {
-    if(!vrChar)
-      vrChar = std::make_unique<VRCharacter>(*w);
-    vrChar->setTransform(pl.position(), rot);
-    float forward = movement.forwardBackward.value();
-    float strafe  = movement.strafeRightLeft.value();
-    Tempest::Vec3 dir{strafe,0.f,forward};
-    float yaw = pl.rotationRad();
-    Tempest::Vec3 v;
-    v.x = dir.x*std::cos(yaw) - dir.z*std::sin(yaw);
-    v.z = dir.x*std::sin(yaw) + dir.z*std::cos(yaw);
-    bool grounded=false;
-    vrChar->move(v*200.f,float(dt)/1000.f,grounded);
-    return;
-  }
-#endif
   if(!pl.isAiQueueEmpty()) {
     runAngleDest = 0;
     return;

--- a/game/game/playercontrol.h
+++ b/game/game/playercontrol.h
@@ -51,8 +51,13 @@ class PlayerControl final {
     bool  tickMove(uint64_t dt);
     bool  tickCameraMove(uint64_t dt);
 
-    void  setVrMove(float strafe, float forward);
-    void  setVrTurn(float turn);
+    // VR hooks
+    void  vrSetWorldPose(const Tempest::Vec3& pos, float yawRad);
+    void  vrMoveDelta(const Tempest::Vec3& delta);
+    void  vrRotateYaw(float yawRad);
+    Tempest::Vec3 getWorldPos() const;
+    float getYaw() const;
+    bool  isOnGround() const;
     void  setVrJump(bool v);
     void  setVrAttack(bool v);
     void  setVrInteract(bool v);
@@ -230,7 +235,6 @@ class PlayerControl final {
     auto handleMovementAction(KeyCodec::ActionMapping actionMapping, bool pressed) -> void;
 #ifdef OPENXR_ENABLED
     std::unique_ptr<VRGrabber> vrGrab;
-    std::unique_ptr<VRCharacter> vrChar;
     std::array<Tempest::Vec3,2> vrHandPos{};
     std::array<Tempest::Vec3,2> vrHandVel{};
     std::array<bool,2>          vrHandHasPrev{{false,false}};

--- a/game/mainwindow.cpp
+++ b/game/mainwindow.cpp
@@ -481,12 +481,14 @@ void MainWindow::keyDownEvent(KeyEvent &event) {
       return;
     }
     if(event.key==Event::K_Q) {
-      vrSnapYaw -= step;
+      if(vrLoco) vrLoco->setSnapTurn(-CommandLine::inst().vrSnapAngle());
+      else player.vrRotateYaw(-step);
       event.accept();
       return;
     }
     if(event.key==Event::K_E) {
-      vrSnapYaw += step;
+      if(vrLoco) vrLoco->setSnapTurn(CommandLine::inst().vrSnapAngle());
+      else player.vrRotateYaw(step);
       event.accept();
       return;
     }
@@ -534,11 +536,13 @@ void MainWindow::keyRepeatEvent(KeyEvent& event) {
   if(xrBackend_!=nullptr) {
     float step = CommandLine::inst().vrSnapAngle()*float(M_PI/180.f);
     if(event.key==Event::K_Q) {
-      vrSnapYaw -= step;
+      if(vrLoco) vrLoco->setSnapTurn(-CommandLine::inst().vrSnapAngle());
+      else player.vrRotateYaw(-step);
       event.accept();
     }
     if(event.key==Event::K_E) {
-      vrSnapYaw += step;
+      if(vrLoco) vrLoco->setSnapTurn(CommandLine::inst().vrSnapAngle());
+      else player.vrRotateYaw(step);
       event.accept();
     }
   }
@@ -973,62 +977,14 @@ uint64_t MainWindow::tick() {
   if(xrBackend_!=nullptr) {
     xrBackend_->pollInput();
     const auto& xr = xrBackend_->inputState();
-    player.setVrMove(xr.move.x*CommandLine::inst().vrMoveSpeedScale(),
-                     xr.move.y*CommandLine::inst().vrMoveSpeedScale());
-    player.setVrTurn(xr.turnX);
-    player.setVrJump(xr.jump);
-    player.setVrAttack(xr.attack);
-    player.setVrInteract(xr.interact);
-    player.setVrMenu(xr.menu);
-
+    if(vrLoco)
+      vrLoco->tick(double(dt)/1000.0, xr);
     if(xr.attack && !vrAttackPrev && CommandLine::inst().vrHaptics()) {
       auto dom = CommandLine::inst().vrDominantHand();
       IXRBackend::XRHand h = (dom==CommandLine::VrHand::Left ? IXRBackend::XRHand::Left : IXRBackend::XRHand::Right);
       xrBackend_->hapticPulse(h,0.5f,0.05f);
     }
     vrAttackPrev = xr.attack;
-
-    if(CommandLine::inst().vrIsSmoothTurn()) {
-      vrSnapYaw += xr.turnX * CommandLine::inst().vrTurnSpeed() * (float(dt)/1000.f) * float(M_PI/180.0);
-    } else {
-      float dz = CommandLine::inst().vrTurnDeadzone();
-      if(std::fabs(xr.turnX) > dz) {
-        uint64_t now = Tempest::Application::tickCount();
-        if(now - vrSnapTime > uint64_t(CommandLine::inst().vrSnapCooldown())) {
-          float step = CommandLine::inst().vrSnapAngle()*float(M_PI/180.f);
-          vrSnapYaw += (xr.turnX>0.f?1.f:-1.f)*step;
-          vrSnapTime = now;
-        }
-      }
-    }
-
-    if(CommandLine::inst().vrTeleport() && xr.teleportClick && !vrTelePrev && xr.aim.valid) {
-      auto w = Gothic::inst().world();
-      auto pl = w ? w->player() : nullptr;
-      if(pl!=nullptr) {
-        if(!vrNav)
-          vrNav = std::make_unique<VRNav>(*w);
-        Tempest::Vec3 dst;
-        bool ok = vrNav->findWalkable(xr.aim.pos + xr.aim.dir*500.f, dst, CommandLine::inst().vrTeleportMaxSlope());
-        if(ok) {
-          if(CommandLine::inst().vrKeepHeading()) {
-            float yaw = std::atan2(xr.aim.dir.x, xr.aim.dir.z)*180.f/float(M_PI);
-            pl->setDirection(yaw);
-          }
-          pl->setPosition(dst);
-          if(CommandLine::inst().vrHaptics()) {
-            auto dom = CommandLine::inst().vrDominantHand();
-            IXRBackend::XRHand h = (dom==CommandLine::VrHand::Left ? IXRBackend::XRHand::Left : IXRBackend::XRHand::Right);
-            xrBackend_->hapticPulse(h,0.5f,0.05f);
-          }
-        } else if(CommandLine::inst().vrHaptics()) {
-          auto dom = CommandLine::inst().vrDominantHand();
-          IXRBackend::XRHand h = (dom==CommandLine::VrHand::Left ? IXRBackend::XRHand::Left : IXRBackend::XRHand::Right);
-          xrBackend_->hapticPulse(h,0.15f,0.03f);
-        }
-      }
-    }
-    vrTelePrev = xr.teleportClick;
   }
 
   if(dialogs.isActive())
@@ -1240,6 +1196,19 @@ void MainWindow::onWorldLoaded() {
     pl->multSpeed(1.f);
   lastTick = Application::tickCount();
   player.clearFocus();
+#ifdef OPENXR_ENABLED
+  if(CommandLine::inst().isVr()) {
+    if(auto w = Gothic::inst().world()) {
+      vrChar = std::make_unique<VRCharacter>(*w);
+      vrNav  = std::make_unique<VRNav>(*w);
+      vrLoco = std::make_unique<vr::VRLocomotion>(player, *vrChar, *vrNav, CommandLine::inst());
+    }
+  } else {
+    vrLoco.reset();
+    vrChar.reset();
+    vrNav.reset();
+  }
+#endif
   }
 
 void MainWindow::onSessionExit() {
@@ -1349,17 +1318,6 @@ void MainWindow::render(){
           }
         }
 #endif
-        if(vrSnapYaw!=0.f) {
-          Matrix4x4 rot;
-          rot.identity();
-          rot.rotateOY(vrSnapYaw);
-          for(auto& eye:views) {
-            Matrix4x4 m = rot;
-            m.mul(eye.view);
-            eye.view = m;
-          }
-        }
-
         if(auto cam = Gothic::inst().camera()) {
           if(CommandLine::inst().isVrFirstPerson())
             cam->setExternalViewProj(&views[0].view,&views[0].proj);
@@ -1500,7 +1458,6 @@ void MainWindow::render(){
           xrBackend_->shutdown();
           delete xrBackend_;
           xrBackend_ = nullptr;
-          vrSnapYaw = 0.f;
         }
         return;
       }

--- a/game/mainwindow.h
+++ b/game/mainwindow.h
@@ -46,6 +46,8 @@ class Interactive;
 #ifdef OPENXR_ENABLED
 #include <vulkan/vulkan.h>
 #include "navigation/vrnav.h"
+#include "physics/vrchar.h"
+#include "vr/locomotion.h"
 struct HudImageInfo {
   VkImage image = VK_NULL_HANDLE;
   int     w = 0;
@@ -197,9 +199,6 @@ class MainWindow : public Tempest::Window {
     Fps        fps;
     Benchmark  benchmark;
     uint64_t   maxFpsInv = 0;
-    float      vrSnapYaw = 0.f;
-    uint64_t   vrSnapTime = 0;
-    bool       vrTelePrev = false;
     bool       vrAttackPrev = false;
 
     Tempest::Attachment vrHud;
@@ -213,7 +212,9 @@ class MainWindow : public Tempest::Window {
     uint64_t             vrPointerPressTime = 0;
     int                  vrPointerX = 0;
     int                  vrPointerY = 0;
+    std::unique_ptr<VRCharacter> vrChar;
     std::unique_ptr<VRNav> vrNav;
+    std::unique_ptr<vr::VRLocomotion> vrLoco;
     bool                 vrSqueezePrev[2] = {false,false};
 #endif
   };

--- a/game/navigation/vrnav.cpp
+++ b/game/navigation/vrnav.cpp
@@ -22,4 +22,9 @@ bool VRNav::findWalkable(const Tempest::Vec3& hint, Tempest::Vec3& out, float ma
   return false;
 }
 
+bool VRNav::isWalkable(const Tempest::Vec3& pos, float maxSlopeDeg) {
+  Tempest::Vec3 tmp{};
+  return findWalkable(pos, tmp, maxSlopeDeg);
+}
+
 #endif

--- a/game/navigation/vrnav.h
+++ b/game/navigation/vrnav.h
@@ -9,6 +9,7 @@ class VRNav {
   public:
     explicit VRNav(World& w);
     bool findWalkable(const Tempest::Vec3& hint, Tempest::Vec3& out, float maxSlopeDeg);
+    bool isWalkable(const Tempest::Vec3& pos, float maxSlopeDeg);
   private:
     World& world;
 };

--- a/game/physics/vrchar.cpp
+++ b/game/physics/vrchar.cpp
@@ -5,6 +5,7 @@
 #include "../world/objects/npc.h"
 #include "../commandline.h"
 #include "dynamicworld.h"
+#include <algorithm>
 
 VRCharacter::VRCharacter(World& w)
   : world(w) {
@@ -14,32 +15,34 @@ VRCharacter::VRCharacter(World& w)
 
 void VRCharacter::setTransform(const Tempest::Vec3& pos, float /*yaw*/) {
   npc = world.player();
-  if(npc)
-    npc->setPosition(pos);
+  this->pos = pos;
+  this->yaw = 0.f;
   lastGround = pos.y;
 }
 
 Tempest::Vec3 VRCharacter::move(const Tempest::Vec3& v, float dt, bool& grounded) {
   grounded = false;
   if(npc==nullptr)
-    return {};
+    return pos;
 
-  Tempest::Vec3 dp = v*dt;
-  npc->tryMove(dp);
-  Tempest::Vec3 pos = npc->position();
+  Tempest::Vec3 to = pos + v*dt;
+  DynamicWorld::CollisionTest out;
+  auto& item = npc->physic;
+  bool ok = item.testMove(to, out);
+  Tempest::Vec3 np = ok ? to : out.partial;
   if(auto phys = world.physic()) {
-    auto r = phys->landRay(pos, stepOffset*2.f);
+    auto r = phys->landRay(np, stepOffset*2.f);
     if(r.hasCol) {
       float slope = std::acos(std::clamp(r.n.y,-1.f,1.f))*180.f/float(M_PI);
       if(slope<=slopeLimitDeg) {
-        pos.y = r.v.y;
-        npc->setPosition(pos);
+        np.y = r.v.y;
         grounded = true;
-        lastGround = pos.y;
+        lastGround = np.y;
       }
     }
   }
-  return npc->position();
+  pos = np;
+  return pos;
 }
 
 float VRCharacter::raycastDown(const Tempest::Vec3& pos, float maxDist, Tempest::Vec3& normal) {

--- a/game/physics/vrchar.h
+++ b/game/physics/vrchar.h
@@ -17,6 +17,8 @@ class VRCharacter {
   private:
     World&  world;
     Npc*    npc = nullptr;
+    Tempest::Vec3 pos{};
+    float   yaw = 0.f;
     float   stepOffset = 30.f;
     float   slopeLimitDeg = 45.f;
     float   lastGround = 0.f;

--- a/game/vr/locomotion.cpp
+++ b/game/vr/locomotion.cpp
@@ -1,0 +1,108 @@
+#include "locomotion.h"
+#ifdef OPENXR_ENABLED
+#include <Tempest/Application>
+#include <cmath>
+#include "../game/playercontrol.h"
+#include "../physics/vrchar.h"
+#include "../navigation/vrnav.h"
+#include "../commandline.h"
+
+using namespace Tempest;
+
+vr::VRLocomotion::VRLocomotion(PlayerControl& pc, VRCharacter& ch, VRNav& nv, const CommandLine& cmd)
+  : player(pc), vrChar(ch), nav(nv), cmd(cmd) {
+}
+
+void vr::VRLocomotion::setEnabled(bool e) {
+  enabled = e;
+}
+
+void vr::VRLocomotion::setSnapTurn(float deg) {
+  queuedSnap += deg;
+}
+
+void vr::VRLocomotion::smoothTurn(float yawRad) {
+  queuedSmooth += yawRad;
+}
+
+void vr::VRLocomotion::requestTeleport(const Vec3& hint, bool keepHeading) {
+  teleReq = true;
+  teleHint = hint;
+  teleKeepHeading = keepHeading;
+}
+
+static Vec3 rotateYaw(float yaw, const Vec3& v) {
+  Vec3 r;
+  r.x = v.x*std::cos(yaw) - v.z*std::sin(yaw);
+  r.z = v.x*std::sin(yaw) + v.z*std::cos(yaw);
+  r.y = v.y;
+  return r;
+}
+
+void vr::VRLocomotion::tick(double dt, const IXRBackend::XRInputState& in) {
+  if(!enabled)
+    return;
+
+  player.setVrJump(in.jump);
+  player.setVrAttack(in.attack);
+  player.setVrInteract(in.interact);
+  player.setVrMenu(in.menu);
+
+  if(cmd.vrTeleport() && in.teleportClick && !teleClickPrev && in.aim.valid) {
+    requestTeleport(in.aim.pos + in.aim.dir*500.f, cmd.vrKeepHeading());
+  }
+  teleClickPrev = in.teleportClick;
+
+  if(teleReq) {
+    Vec3 dst{};
+    if(nav.findWalkable(teleHint, dst, cmd.vrTeleportMaxSlope())) {
+      player.vrSetWorldPose(dst, player.getYaw());
+      teleportOk = true;
+      rejectReason = nullptr;
+    } else {
+      teleportOk = false;
+      rejectReason = "nav";
+    }
+    teleReq = false;
+  }
+
+  Vec3 wish{in.move.x,0.f,in.move.y};
+  if(wish.x!=0.f || wish.z!=0.f)
+    wish = rotateYaw(player.getYaw(), wish);
+
+  Vec3 wishVel = wish * cmd.vrWalkMaxSpeed();
+  Vec3 dv = wishVel - velocity;
+  float maxDv = cmd.vrWalkAccel()*dt;
+  float len = std::sqrt(dv.x*dv.x + dv.y*dv.y + dv.z*dv.z);
+  if(len>maxDv && len>0.f)
+    dv *= maxDv/len;
+  velocity += dv;
+
+  Vec3 pos0 = player.getWorldPos();
+  vrChar.setTransform(pos0, player.getYaw());
+  Vec3 pos1 = vrChar.move(velocity*100.f, float(dt), grounded);
+  Vec3 dpos = pos1 - pos0;
+  if(dpos.x!=0.f || dpos.y!=0.f || dpos.z!=0.f)
+    player.vrMoveDelta(dpos);
+
+  float yawDelta = 0.f;
+  if(cmd.vrIsSmoothTurn()) {
+    yawDelta += queuedSmooth;
+    queuedSmooth = 0.f;
+    yawDelta += in.turnX * cmd.vrTurnSpeed() * float(dt) * float(M_PI/180.0);
+    if(yawDelta!=0.f)
+      player.vrRotateYaw(yawDelta);
+  } else {
+    uint64_t now = Tempest::Application::tickCount();
+    if(std::fabs(in.turnX) > cmd.vrTurnDeadzone() && now - lastSnapTime > uint64_t(cmd.vrSnapCooldown())) {
+      queuedSnap += (in.turnX>0.f?1.f:-1.f) * cmd.vrSnapAngle();
+      lastSnapTime = now;
+    }
+    if(queuedSnap!=0.f) {
+      player.vrRotateYaw(queuedSnap*float(M_PI/180.0));
+      queuedSnap = 0.f;
+    }
+  }
+}
+
+#endif

--- a/game/vr/locomotion.h
+++ b/game/vr/locomotion.h
@@ -1,0 +1,47 @@
+#pragma once
+#ifdef OPENXR_ENABLED
+#include <Tempest/Vec3>
+#include <xr/IXRBackend.h>
+#include <cstdint>
+
+class PlayerControl;
+class VRCharacter;
+class VRNav;
+class CommandLine;
+
+namespace vr {
+class VRLocomotion {
+  public:
+    VRLocomotion(PlayerControl&, VRCharacter&, VRNav&, const CommandLine&);
+    void setEnabled(bool e);
+    void setSnapTurn(float deg);
+    void smoothTurn(float yawRad);
+    void requestTeleport(const Tempest::Vec3& hint, bool keepHeading);
+    void tick(double dt, const IXRBackend::XRInputState& in);
+
+    bool isGrounded() const { return grounded; }
+    bool lastTeleportOk() const { return teleportOk; }
+    const char* lastRejectReason() const { return rejectReason; }
+  private:
+    PlayerControl&  player;
+    VRCharacter&    vrChar;
+    VRNav&          nav;
+    const CommandLine& cmd;
+
+    bool            enabled = true;
+    Tempest::Vec3   velocity{}; // m/s
+    bool            grounded = false;
+
+    float           queuedSnap = 0.f; // degrees
+    float           queuedSmooth = 0.f; // radians
+    uint64_t        lastSnapTime = 0;
+
+    bool            teleReq = false;
+    Tempest::Vec3   teleHint{};
+    bool            teleKeepHeading = false;
+    bool            teleportOk = false;
+    const char*     rejectReason = nullptr;
+    bool            teleClickPrev = false;
+};
+}
+#endif


### PR DESCRIPTION
## Summary
- Bridge VR movement through PlayerControl with new VR hooks
- Add VRLocomotion module for unified walking, turning and teleport
- Expose tunable VR walk acceleration and speed options

## Testing
- `cmake -S . -B build -DOPENXR_ENABLED=OFF` *(fails: glslangValidator required)*

------
https://chatgpt.com/codex/tasks/task_e_68c61ac37b108331b0261cb757f54b60